### PR TITLE
chore: add kongctl declarative/extension-builder skills

### DIFF
--- a/.agents/skills/kongctl-declarative
+++ b/.agents/skills/kongctl-declarative
@@ -1,0 +1,1 @@
+../../.kongctl/skills/kongctl-declarative

--- a/.agents/skills/kongctl-extension-builder
+++ b/.agents/skills/kongctl-extension-builder
@@ -1,0 +1,1 @@
+../../.kongctl/skills/kongctl-extension-builder

--- a/.kongctl/skills/.kongctl-skills-manifest.json
+++ b/.kongctl/skills/.kongctl-skills-manifest.json
@@ -1,0 +1,5 @@
+{
+  "cli_version": "1.2.1",
+  "installed_at": "2026-06-02T01:18:32Z",
+  "skills": ["kongctl-declarative", "kongctl-extension-builder"]
+}

--- a/.kongctl/skills/kongctl-declarative/SKILL.md
+++ b/.kongctl/skills/kongctl-declarative/SKILL.md
@@ -1,0 +1,439 @@
+---
+description: Set up, initialize, and manage kongctl declarative configuration for Kong Konnect. Use when the user wants to configure a repository with Konnect declarative resources, create kongctl manifests (control planes, portals, APIs), use kongctl scaffold or kongctl explain to discover schemas and bootstrap resource YAML, integrate decK gateway state through _deck, generate Konnect API and Kong Gateway config from OpenAPI specs, run plan/diff/apply/sync/delete/adopt workflows, or scaffold CI/CD pipelines for Konnect APIOps.
+license: Apache-2.0
+metadata:
+  category: declarative
+  product: kongctl
+  version: 1.2.1
+name: kongctl-declarative
+---
+
+# kongctl declarative workflows
+
+## Goal
+
+Generate and maintain `kongctl` declarative configuration in the repository,
+and teach users how to manage Konnect resources declaratively.
+
+Choose the execution approach from user intent:
+
+- User-run mode: provide commands and explain what each command does.
+- Agent-run mode: execute commands directly and report outcomes.
+
+## Preconditions
+
+- Confirm CLI is installed and runnable: `kongctl version`
+- For Kong Gateway configuration, confirm decK is installed: `deck version`
+- Local schema helpers do not require Konnect authentication:
+  - `kongctl explain <resource-path>` inspects resource and field schemas.
+  - `kongctl scaffold <resource-path>` prints commented starter YAML.
+- Authenticate with one of:
+  - `kongctl login` — preferred for interactive use (browser-based OAuth)
+  - `export KONGCTL_DEFAULT_KONNECT_PAT=<token>` — for non-interactive or CI
+- PAT tokens are sensitive credentials. Never echo, log, or commit them.
+  Prefer `kongctl login` for interactive sessions.
+- Verify authentication works: `kongctl get organization -o json`
+  This works with all token types (PAT, SPAT, browser login). If it
+  returns organization info, auth is confirmed. Do not guess or try other
+  commands to check auth.
+- Verify command syntax when unsure:
+  - `kongctl explain --help`
+  - `kongctl scaffold --help`
+  - `kongctl plan --help`
+  - `kongctl dump declarative --help`
+  - `kongctl adopt --help`
+
+## Config and Environment Overrides
+
+- `kongctl` flags can be defaulted via profile config or environment.
+- Environment variable pattern: `KONGCTL_<PROFILE>_<PATH>`.
+- Example: `KONGCTL_DEFAULT_OUTPUT=yaml` changes default output format.
+- Pass explicit `-o yaml`, `-o json`, or `-o text` on command lines to avoid
+  unexpected output behavior.
+
+## Skill References
+
+Load only the reference file needed for the active task:
+
+- `references/commands.md`
+  - Use for schema helpers, command selection, plan based vs inline execution,
+    and safety flags.
+- `references/resources.md`
+  - Use for schema-first authoring, resource skeletons, `_defaults`, `!file`,
+    and `!ref` patterns.
+- `references/troubleshooting.md`
+  - Use for common failures and fast remediation steps.
+- `references/cicd-github-actions.md`
+  - Use for GitHub Actions workflow patterns for declarative CI/CD.
+- `references/apiops-openapi.md`
+  - Use for OpenAPI source-of-truth patterns for APIs and API versions.
+- `references/deck-gateway.md`
+  - Use when configuring Kong Gateway services, routes, plugins, consumers,
+    or OpenAPI-to-Gateway APIOps with decK and `_deck`.
+
+This skill is designed to be portable across repositories. Do not assume a
+local `docs/` directory exists.
+
+Before hand-writing unfamiliar resources or fields, discover structure with:
+
+```bash
+kongctl explain <resource-path> -o text --extended
+kongctl scaffold <resource-path>
+```
+
+Use `kongctl dump declarative --resources=<resource-type>` when live Konnect
+state is the best source of truth, such as when adopting existing resources.
+
+## Operating Rules
+
+- Declarative execution is always plan-based in kongctl:
+  - Explicit path: `plan` -> `diff --plan` -> `apply/sync --plan`
+  - Inline path: `apply -f`, `sync -f`, or `delete -f` (plan+execute
+    happens in single shot)
+- Prefer instructional guidance when the user asks how to do a task:
+  provide a concise command sequence and decision notes.
+- Execute commands directly when the user asks the agent to run them.
+- Before any mutating run, state the intended effect in plain language.
+- Choose path from user intent:
+  - Preview/review/audit/CI request: use explicit plan artifacts.
+  - "Do it now" execution request: use inline commands.
+- Treat `sync` as destructive because it can delete missing resources.
+- Treat `delete` as destructive because it deletes input configuration
+  resources.
+- Use `apply` for create/update workflows when the user asks to execute.
+- Use `-o text` for interactive mutating commands. `-o json` and `-o yaml`
+  require `--auto-approve` or `--dry-run` on `apply`, `sync`, and `delete`.
+- Use `kongctl explain` before guessing at resource, child-resource, or field
+  structure. Use `--extended` for field summaries in text output, or
+  `-o json`/`-o yaml` for machine-readable schema.
+- Use `kongctl scaffold` to bootstrap YAML for new resource types and child
+  resources. It writes YAML to stdout and does not support `-o/--output`.
+- For programmatic YAML generation, prefer `kongctl explain <path> -o json`
+  as the source of truth. It returns JSON Schema with kongctl metadata.
+- For resources with JSON Schema `oneOf`, choose exactly one branch. Use
+  discriminator `const` fields such as `type` or `strategy_type` to select the
+  branch, and do not merge branch-specific `config` or `configs` blocks.
+- In scaffold output, `# oneOf option: ...` marks mutually exclusive
+  alternatives. One branch is active and the other branches are commented.
+- Use resource and field paths such as `api`, `api.versions`,
+  `api.publications.portal_id`, and `portal.pages` with `explain`.
+- Use resource and child-resource paths such as `api`, `api.versions`, and
+  `control_plane.data_plane_certificates` with `scaffold`.
+- Use `adopt` only to bring unmanaged resources into namespace management.
+- `adopt` only adds the `KONGCTL-namespace` label to the target resource.
+- Prefer `!ref` for cross-resource IDs and `!file` for large spec or
+  doc content.
+- For `apis` and `apis.versions`, treat OpenAPI files as source of truth:
+  derive fields from `!file` extraction and avoid stale duplicated literals.
+- Use existing OpenAPI file paths from the user repository. Do not require a
+  `konnect/resources/specs` layout.
+- Use decK for Kong Gateway runtime entities such as services, routes,
+  plugins, consumers, consumer groups, upstreams, and targets.
+- Use kongctl resources for Konnect SaaS resources such as control planes,
+  portals, API catalog entries, publications, and API implementations.
+- When a user wants an API Gateway configured from OpenAPI, generate decK
+  state with `deck file openapi2kong`, then wire it to kongctl through
+  `control_planes[]._deck`.
+- Use `control_planes[].gateway_services` as external selectors for services
+  created by decK, then reference them from `apis[].implementations`.
+- Only place kongctl declarative resource files in the resources directory.
+  Do not put OpenAPI specs, documentation, or other non-resource YAML there.
+  `--recursive` loads all YAML files in the directory tree and will fail on
+  files that are not valid kongctl declarative resources.
+- When non-resource YAML files coexist in a directory, use multiple `-f`
+  flags pointing to individual resource files instead of `--recursive`:
+  `kongctl diff -f resources/apis.yaml -f resources/portals.yaml --mode apply`
+- `!file` paths resolve relative to the YAML file they appear in, not the
+  project root. Calculate the relative path from the config file to the
+  target file (e.g. `../../openapi.yaml` from `konnect/resources/apis.yaml`).
+- `--base-dir` sets the allowed boundary for `!file` resolution but does
+  not change the resolution base. Keep `!file` targets within the boundary.
+- Put `kongctl` metadata only on parent resources.
+- Use `_defaults.kongctl.namespace` for consistent file-level ownership.
+- Do not require `docs/declarative*.md` to complete tasks.
+
+## Workflow
+
+1. Locate the Konnect declarative configuration directory and existing files.
+2. For unfamiliar resource shapes, run `kongctl explain` or
+   `kongctl scaffold` before writing YAML.
+3. Generate or update YAML manifests and related files.
+4. Choose collaboration mode based on intent:
+   - User-run mode (teach + provide commands)
+   - Agent-run mode (execute commands directly)
+5. Load the relevant `references/*.md` file for the task.
+6. If execution is needed, pick execution style:
+   - Explicit plan artifact workflow (generate plan, then pass it to apply or
+     sync)
+   - Inline command workflow
+7. Validate and/or execute `diff`, `apply`, `sync`, `delete`, or `adopt` per
+   user ask.
+8. Report created files, commands run, and resulting plan or execution
+   summary.
+
+### Execution Style Selection
+
+Use this quick decision rule:
+
+- Use explicit plan artifacts when the user asks to preview, review, export a
+  plan file, or run a CI/CD style workflow.
+- Use inline commands when the user asks to execute immediately and does not
+  ask for a saved plan file.
+- For destructive requests (`sync`, `delete`), prefer `--dry-run` first unless
+  the user explicitly requests direct execution.
+
+### Collaboration Mode Selection
+
+Use this quick decision rule:
+
+- Use User-run mode when the user asks "how do I do this" or asks for commands.
+- Use Agent-run mode when the user asks to set up, create, or apply.
+- If intent is ambiguous, provide a safe preview command first and state that
+  you can execute the mutating command on request.
+- Do not ask clarifying questions when sensible defaults can be inferred
+  from context (e.g. derive namespace from project name, include standard
+  resources like control plane + portal + API). Proceed with defaults and
+  let the user adjust afterward.
+
+### Konnect Configuration Directory Discovery
+
+Prefer a user-provided path. If none is provided, discover likely roots:
+
+```bash
+rg -n --glob '*.y*ml' '^(_defaults|apis|portals|control_planes):' .
+rg -n --glob '*.y*ml' \
+  '^(application_auth_strategies|event_gateways|organization):' .
+```
+
+If creating new structure, prefer:
+
+```text
+konnect/resources/
+  control-planes.yaml
+  portals.yaml
+  apis.yaml
+```
+
+For APIOps API modeling, load `references/apiops-openapi.md`.
+For Kong Gateway/deck integration, load `references/deck-gateway.md`.
+
+## Pattern: Bootstrap control plane, portal, and APIs
+
+Use for prompts like:
+
+- Generate declarative configs for a new control plane, portal, and API set.
+
+Steps:
+
+1. Create or update resource files under the selected resources path.
+2. Add `_defaults.kongctl.namespace` and stable `ref` values.
+3. Use `!file` tags to load OpenAPI metadata and version content.
+4. Link API publications to portal using `!ref <portal-ref>#id`.
+5. Validate and execute based on requested style.
+6. In User-run mode, explain each command's purpose before listing it.
+
+Starter manifest pattern:
+
+When starting from scratch, prefer generating starter shapes first:
+
+```bash
+kongctl scaffold control_plane
+kongctl scaffold portal
+kongctl scaffold api
+```
+
+Then adapt the generated YAML to the repository layout and user intent. The
+static pattern below is a compact fallback and example of the expected result.
+
+```yaml
+_defaults:
+  kongctl:
+    namespace: platform-dev
+    protected: false
+
+control_planes:
+  - ref: cp-main
+    name: 'my-control-plane'
+    cluster_type: 'CLUSTER_TYPE_CONTROL_PLANE'
+
+portals:
+  - ref: dev-portal
+    name: 'my-dev-portal'
+    display_name: 'My Dev Portal'
+    default_api_visibility: 'private'
+    default_page_visibility: 'private'
+
+apis:
+  - ref: payments-api
+    name: !file <existing-openapi-path>#info.title
+    description: !file <existing-openapi-path>#info.description
+    versions:
+      - ref: payments-v1
+        version: !file <existing-openapi-path>#info.version
+        spec: !file <existing-openapi-path>
+    publications:
+      - ref: payments-publication
+        portal_id: !ref dev-portal#id
+        visibility: public
+```
+
+When OpenAPI `!file` paths point outside the resources directory, set
+`--base-dir` to the absolute project root so paths resolve correctly.
+Relative `--base-dir` values resolve from the config file directory, not
+cwd, so always use an absolute path:
+
+```bash
+kongctl diff -f konnect/resources --recursive \
+  --base-dir "$(pwd)" --mode apply -o text
+```
+
+Use `--recursive` when the `-f` target is a directory.
+
+Use `references/commands.md` for validation and execution command patterns.
+
+## Pattern: Generate API config from an OpenAPI spec
+
+Use for prompts like:
+
+- Generate an API declarative config from `@path-to/openapi-spec.yaml` and
+  write it to `@path-to-existing/konnect/resources`.
+- Generate gateway services, routes, and plugins from an OpenAPI spec and
+  connect them to a Konnect API implementation.
+
+Steps:
+
+1. Choose target files under the existing resources tree, such as:
+   - `<resources>/apis/<api-name>.yaml`
+2. If no local API manifest convention exists, run `kongctl scaffold api`
+   and adapt the generated shape.
+3. If the user wants Gateway runtime config, load
+   `references/deck-gateway.md` and create or update a decK state file.
+4. Reference existing OpenAPI spec paths in the repository. Do not require
+   copying specs under the declarative resources directory.
+5. Preserve existing repo conventions when a layout already exists.
+6. Reference spec fields with `!file` extraction.
+7. If spec files are outside the resources directory, add `--base-dir` to
+   all `plan`/`diff`/`apply`/`sync` commands so `!file` paths resolve.
+8. Validate and execute based on requested style.
+9. In User-run mode, include where files were written and why.
+
+Load `references/apiops-openapi.md` for the canonical API YAML template and
+`references/commands.md` for validation and execution commands.
+Load `references/deck-gateway.md` when the OpenAPI spec should also produce
+Gateway services, routes, plugins, or an API implementation backed by decK.
+
+## Pattern: Adopt existing resources into declarative management
+
+Use for prompts like:
+
+- Adopt portal `My Dev Portal` and start managing it declaratively.
+- I have resources in Konnect that I created in the UI. How do I bring them
+  under kongctl?
+- Dump my existing control plane into declarative config.
+
+This pattern applies to any parent resource type (portal, api, control_plane,
+etc.), not just portals.
+
+### Background
+
+Resources created outside kongctl (e.g. via the Konnect UI) do not have a
+`KONGCTL-namespace` label. The declarative engine uses this label to track
+which resources it manages and which namespace they belong to. To bring an
+existing resource under declarative management:
+
+1. **Adopt** adds the `KONGCTL-namespace` label to the live resource.
+2. **Dump** exports the live resource state as declarative YAML.
+3. **Integrate** the dumped config into the repository's declarative files.
+4. **Verify** with `diff` to confirm zero drift.
+
+Adopt must come before dump so the resource is labeled as managed before
+generating config.
+
+### Steps
+
+1. Identify the target resource name (or ID) and choose a namespace.
+2. Adopt the resource into the namespace:
+   ```bash
+   kongctl adopt <resource-type> <name-or-id> \
+     --namespace <namespace> -o json
+   ```
+   This only adds the `KONGCTL-namespace` label — it does not modify the
+   resource configuration.
+3. Dump the resource to declarative YAML:
+   ```bash
+   kongctl dump declarative \
+     --resources=<type> \
+     --filter-name "<name>" \
+     --include-child-resources \
+     --default-namespace <namespace> \
+     -o yaml \
+     --output-file <output-path>
+   ```
+4. Integrate the dumped output into existing declarative files:
+   - Replace the UUID-based `ref` values with human-friendly names.
+   - Replace hard-coded UUIDs with `!ref` where the referenced resource is
+     also managed declaratively (e.g. `portal_id: !ref dev-portal#id`).
+   - Merge into existing resource files or create new ones following the
+     repository layout conventions.
+   - Ensure `_defaults.kongctl.namespace` matches the adopt namespace.
+5. Verify zero drift:
+   ```bash
+   kongctl diff -f <resources-path> --mode apply -o text
+   ```
+   A clean diff confirms the dumped config matches live state.
+6. In User-run mode, explain that `adopt` only labels — it does not change
+   any resource fields.
+
+### Dump output behavior
+
+- `dump` sets `ref` to the resource UUID. Replace with meaningful names.
+- `dump` filters out `KONGCTL-namespace` labels from output by design.
+- `--default-namespace` adds a `_defaults.kongctl` block to the output.
+- `--include-child-resources` includes nested resources (pages, snippets,
+  versions, etc.).
+- Use `--filter-name` or `--filter-id` to scope to a specific resource.
+
+If names are ambiguous, use `--filter-id` for both adopt and dump.
+
+## Pattern: Build GitHub Actions workflow for declarative CI/CD
+
+Use for prompts like:
+
+- Create a GitHub Actions workflow that validates and syncs Konnect
+  declarative resources.
+- Add CI/CD automation that installs `kongctl` and `deck` and runs the
+  repository sync script.
+
+Steps:
+
+1. Decide trigger model from user intent:
+   - Pull request validation: run plan/diff only (no mutations).
+   - Branch deploy workflow: run apply/sync or a repo wrapper script.
+2. Use standard setup actions:
+   - `actions/checkout@v4`
+   - `kong/setup-kongctl@v1`
+   - `kong/setup-deck@v1` (when deck is required)
+3. Configure authentication using repository secrets and workflow env.
+4. Restrict execution with path filters, for example `konnect/**`.
+5. Upload execution artifacts with `if: always()` for debugging and audits.
+6. In User-run mode, explain required secrets and expected script behavior.
+
+Load `references/cicd-github-actions.md` for starter workflow templates,
+trigger patterns, auth conventions, and validation workflow examples.
+
+## Safety and Troubleshooting
+
+- Use `--dry-run` for `apply`, `sync`, and `delete` before executing changes.
+- If `!file` fails with boundary errors, set `--base-dir` to include spec
+  paths rather than moving files.
+- If `plan` includes unexpected deletes, use `--mode apply` or tighten scope
+  with `--require-namespace`.
+- Load `references/troubleshooting.md` for detailed remediation steps.
+
+## Online Documentation
+
+If this skill's references are not sufficient, consult or direct users to:
+
+- kongctl docs: https://developer.konghq.com/kongctl/
+- Declarative guide: https://github.com/Kong/kongctl/blob/main/docs/declarative.md
+- Resource reference: https://github.com/Kong/kongctl/blob/main/docs/declarative-resource-reference.md

--- a/.kongctl/skills/kongctl-declarative/agents/openai.yaml
+++ b/.kongctl/skills/kongctl-declarative/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Kongctl Declarative'
+  short_description: 'Build schema-valid kongctl and decK configs'
+  default_prompt: 'Use $kongctl-declarative to generate schema-valid Konnect and decK Gateway declarative config with scaffold/explain, then plan or diff it safely.'

--- a/.kongctl/skills/kongctl-declarative/references/apiops-openapi.md
+++ b/.kongctl/skills/kongctl-declarative/references/apiops-openapi.md
@@ -1,0 +1,81 @@
+# APIOps OpenAPI Source of Truth
+
+Use this file when generating or updating declarative `apis` resources from
+OpenAPI documents.
+
+## Core Rule
+
+Treat OpenAPI files as the source of truth for:
+
+- `apis[].name`
+- `apis[].description`
+- `apis[].version`
+- `apis[].versions[].version`
+- `apis[].versions[].spec`
+
+Prefer `!file` extraction over duplicated literal values so API metadata stays
+aligned with spec changes.
+
+## Modeling Pattern
+
+1. Keep OpenAPI files in their existing repository locations.
+2. Do not require moving specs under `konnect/resources/` unless the user asks.
+3. Store one or more specs per API (one per version when versioned specs are
+   separate).
+4. Populate API metadata from `info.*` in each OpenAPI file.
+5. Keep `versions[].spec` pointing to the full OpenAPI document file.
+
+## Gateway APIOps Split
+
+OpenAPI can drive two related outputs:
+
+- Konnect API catalog config (`apis`, `versions`, `publications`) using
+  `!file` extraction.
+- Kong Gateway runtime config using decK (`services`, `routes`, `plugins`).
+
+When the user asks to "set up an API Gateway", "create routes/services", or
+"configure plugins" from OpenAPI, also load
+`references/deck-gateway.md`. Generate decK state with
+`deck file openapi2kong`, then wire the resulting service into kongctl with
+`control_planes[]._deck`, external `gateway_services`, and
+`apis[].implementations`.
+
+## Canonical Example
+
+```yaml
+apis:
+  - ref: sms
+    name: !file <path-to-existing-openapi-spec-v1>#info.title
+    description: !file <path-to-existing-openapi-spec-v1>#info.description
+    version: !file <path-to-existing-openapi-spec-v1>#info.version
+    versions:
+      - ref: sms-v1
+        version: !file <path-to-existing-openapi-spec-v1>#info.version
+        spec: !file <path-to-existing-openapi-spec-v1>
+      - ref: sms-v2
+        version: !file <path-to-existing-openapi-spec-v2>#info.version
+        spec: !file <path-to-existing-openapi-spec-v2>
+```
+
+## Repository Example
+
+When working in the `kongctl` repository, use this concrete example:
+
+- `docs/examples/declarative/portal/apis.yaml`
+- `docs/examples/declarative/deck/`
+
+## Validation Loop
+
+After generating or updating API config:
+
+```bash
+kongctl diff -f <resources-path> --recursive --mode apply -o text
+```
+
+When OpenAPI specs are outside the resources directory, add `--base-dir`
+with the absolute project root:
+
+```bash
+kongctl diff -f <resources-path> --recursive \
+  --base-dir "$(pwd)" --mode apply -o text
+```

--- a/.kongctl/skills/kongctl-declarative/references/cicd-github-actions.md
+++ b/.kongctl/skills/kongctl-declarative/references/cicd-github-actions.md
@@ -1,0 +1,154 @@
+# Declarative CI/CD with GitHub Actions
+
+Use this file when asked to create or modify GitHub Actions workflows for
+`kongctl` declarative operations.
+
+## Workflow Design Checklist
+
+1. Confirm trigger intent:
+   - Pull request validation only
+   - Branch deployment (for example `main`)
+   - Manual execution (`workflow_dispatch`)
+2. Separate non-mutating and mutating behavior:
+   - Validation jobs should run `plan` or `diff`.
+   - Deployment jobs can run `apply` or `sync`.
+3. Install required tooling:
+   - `kong/setup-kongctl@v1`
+   - `kong/setup-deck@v1` when `_deck` is declared or APIOps scripts run
+4. Inject secrets via workflow `env` or step-level `env`.
+5. Upload artifacts for audit and troubleshooting.
+
+## Trigger Patterns
+
+Validation on pull request:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - konnect/**
+```
+
+Deployment on main branch:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - konnect/**
+```
+
+Manual fallback:
+
+```yaml
+on:
+  workflow_dispatch:
+```
+
+## Common Job Steps
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - name: Install kongctl
+    uses: kong/setup-kongctl@v1
+  - name: Install deck
+    uses: kong/setup-deck@v1
+```
+
+Use a repository script when available (`./scripts/konnect-sync.sh`) so CI
+logic and local developer flows stay aligned.
+
+When OpenAPI specs generate Gateway config, put the `deck file openapi2kong`,
+`deck file patch`, `deck file add-plugins`, and `deck file add-tags` calls in
+a repository script. Run that script before `kongctl plan`, `diff`, `apply`,
+or `sync` so `_deck.files` points at generated decK state.
+
+## Auth and Environment Conventions
+
+- Keep credentials in GitHub Secrets.
+- Match environment variable names to repository scripts.
+- Common names:
+  - `KONNECT_TOKEN`
+  - `KONNECT_REGION`
+- For direct `kongctl` commands, you can also map:
+  - `KONGCTL_DEFAULT_KONNECT_PAT: ${{ secrets.KONNECT_TOKEN }}`
+
+## Deployment Workflow Pattern
+
+Use this pattern for a main-branch sync with artifact capture:
+
+```yaml
+name: Konnect Sync
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - konnect/**
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kongctl
+        uses: kong/setup-kongctl@v1
+      - name: Install deck
+        uses: kong/setup-deck@v1
+      - name: Sync Konnect resources
+        env:
+          KONNECT_TOKEN: ${{ secrets.KONNECT_TOKEN }}
+          KONNECT_REGION: ${{ secrets.KONNECT_REGION }}
+        run: ./scripts/konnect-sync.sh
+      - name: Upload Konnect sync artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: konnect-sync
+          path: .konnect/
+```
+
+## Validation Workflow Pattern
+
+Use this pattern for pull-request safety checks:
+
+```yaml
+name: Konnect Validate
+
+on:
+  pull_request:
+    paths:
+      - konnect/**
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kongctl
+        uses: kong/setup-kongctl@v1
+      - name: Validate declarative config
+        env:
+          KONGCTL_DEFAULT_KONNECT_PAT: ${{ secrets.KONNECT_TOKEN }}
+        run: |
+          kongctl plan -f konnect/resources --recursive --mode apply -o json \
+            --output-file .konnect/plan.json
+          kongctl diff -f konnect/resources --recursive --mode apply -o text
+      - name: Upload validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: konnect-validate
+          path: .konnect/
+```
+
+## APIOps Extension Point
+
+When users ask for OpenAPI-to-gateway automation, keep the workflow structure
+above and add repository-specific APIOps steps in scripts. Prefer script calls
+over long inline command chains for maintainability.

--- a/.kongctl/skills/kongctl-declarative/references/commands.md
+++ b/.kongctl/skills/kongctl-declarative/references/commands.md
@@ -1,0 +1,258 @@
+# Declarative Command Reference
+
+Use this file for fast command selection and execution patterns.
+Use it in both modes:
+
+- User-run mode: provide commands and explain intent/effect.
+- Agent-run mode: execute commands and report outcomes.
+
+Use command help for ground-truth syntax in environments without local docs.
+
+## Command Roles
+
+- `kongctl explain`: Inspect declarative schema for a resource path or field.
+- `kongctl scaffold`: Generate commented starter YAML for a resource path.
+- `kongctl plan`: Generate a plan artifact without executing changes.
+- `kongctl diff`: Preview planned changes in text, JSON, or YAML.
+- `kongctl apply`: Create and update resources. No deletes.
+- `kongctl sync`: Create, update, and delete to match desired state.
+- `kongctl delete`: Delete resources defined in the input files.
+- `kongctl dump declarative`: Export live resources into declarative YAML.
+- `kongctl adopt`: Label existing resources with `KONGCTL-namespace`.
+- `deck file openapi2kong`: Convert OpenAPI to decK Gateway state.
+- `deck file patch`: Apply JSONPath-based patches to decK files.
+- `deck file add-plugins`: Add plugins to selected decK entities.
+- `deck file add-tags`: Add tags to selected decK entities.
+
+## Intent to Command
+
+Use these intent mappings:
+
+1. Discover fields, required values, nesting, or YAML placement
+   `kongctl explain <resource-path> --extended -o text`
+   `kongctl explain <resource-path> -o json`
+2. Generate starter YAML for a resource or child resource
+   `kongctl scaffold <resource-path>`
+3. Preview create/update only
+   `kongctl diff -f <path> --mode apply -o text`
+4. Preview full converge including deletes
+   `kongctl diff -f <path> --mode sync -o text`
+5. Generate a reviewable plan file
+   `kongctl plan -f <path> --mode <apply|sync|delete> --output-file <plan.json>`
+6. Execute a saved plan artifact
+   `kongctl apply --plan <plan.json>`
+   `kongctl sync --plan <plan.json>`
+7. Execute create/update now (inline plan+execute)
+   `kongctl apply -f <path> --dry-run -o text`
+   `kongctl apply -f <path> -o text`
+8. Execute full converge now (inline plan+execute)
+   `kongctl sync -f <path> --dry-run -o text`
+   `kongctl sync -f <path> -o text`
+9. Execute delete workflow now
+   `kongctl delete -f <path> --dry-run -o text`
+   `kongctl delete -f <path> -o text`
+10. Dump existing resources to declarative YAML
+    `kongctl dump declarative --resources=<types> -o yaml --output-file <file>`
+11. Adopt unmanaged resource into a namespace
+    `kongctl adopt <resource> <name-or-id> --namespace <namespace> -o json`
+12. Generate Gateway runtime config from OpenAPI
+
+```bash
+deck file openapi2kong \
+  --spec <openapi.yaml> \
+  --select-tag <tag> \
+  --output-file <gateway.yaml>
+```
+
+13. Patch or enrich generated decK state
+
+```bash
+deck file patch --state <gateway.yaml> --output-file <out.yaml>
+deck file add-plugins --state <gateway.yaml> --output-file <out.yaml>
+deck file add-tags --state <gateway.yaml> --output-file <out.yaml> <tag>
+```
+
+## Explain Command Detail
+
+`kongctl explain` is the first choice for schema questions. It works without
+Konnect authentication and accepts resource, child-resource, and field paths.
+
+```bash
+kongctl explain <resource-path> --extended -o text
+kongctl explain <resource-path> -o json
+kongctl explain <resource-path> -o yaml
+```
+
+Resource path examples:
+
+- `api`
+- `api.versions`
+- `api.publications.portal_id`
+- `portal.pages`
+- `control_plane.data_plane_certificates`
+
+Use text output for human-readable summaries. Use `--extended` with text
+output when field details are needed. Use `-o json` or `-o yaml` when an
+agent needs machine-readable JSON Schema, required fields, root keys,
+resource class, or nesting metadata.
+
+For programmatic authoring, treat JSON Schema as the source of truth. When a
+schema contains `oneOf`, choose exactly one branch. Branches commonly use a
+discriminator field with `const`, such as `strategy_type: key_auth` or
+`type: tls_server`.
+
+## Scaffold Command Detail
+
+`kongctl scaffold` prints commented YAML starter configuration for a resource
+path. Use it before hand-writing new resource shapes.
+
+```bash
+kongctl scaffold api
+kongctl scaffold api.versions
+kongctl scaffold control_plane.data_plane_certificates
+```
+
+Important behavior:
+
+- It writes YAML to stdout.
+- It does not support `-o` or `--output`.
+- To save output in User-run mode, tell the user to redirect stdout:
+  `kongctl scaffold api > konnect/resources/apis.yaml`
+- Replace placeholder refs and values such as `my-resource` before planning.
+- Un-comment optional fields only when the user needs them.
+- `# oneOf option: ...` marks mutually exclusive alternatives.
+- One `oneOf` branch is active and the other branches are commented.
+- To switch variants, uncomment one whole branch and comment or remove the
+  previously active branch.
+- Common fields outside `# oneOf option: ...` blocks apply to all variants.
+- Do not merge branch-specific `config` or `configs` blocks from multiple
+  `oneOf` options.
+
+## decK APIOps Command Detail
+
+Use decK file commands when generating or modifying Kong Gateway runtime
+configuration files. These commands work on local files and are separate from
+the `kongctl apply/sync` execution that later runs decK through `_deck`.
+
+```bash
+deck file openapi2kong --spec <openapi.yaml> --select-tag <tag> \
+  --output-file <gateway.yaml>
+deck file patch --state <gateway.yaml> --selector '$..services[*]' \
+  --value 'read_timeout:30000' --output-file <patched.yaml>
+deck file add-plugins --state <gateway.yaml> --selector '$..services[*]' \
+  --config '{"name":"key-auth"}' --output-file <plugins.yaml>
+deck file add-tags --state <gateway.yaml> --selector 'services[*]' \
+  --output-file <tagged.yaml> <tag>
+```
+
+Load `references/deck-gateway.md` for `_deck`, select-tag, external
+`gateway_services`, and API implementation wiring patterns.
+
+## Adopt Command Detail
+
+`kongctl adopt` labels an existing Konnect resource with
+`KONGCTL-namespace: <namespace>` so the declarative engine recognizes it as
+managed. Adopt does not modify any resource fields — it only sets the label.
+
+```bash
+kongctl adopt <resource-type> <name-or-id> --namespace <namespace> -o json
+```
+
+- `<resource-type>`: parent resource type (e.g. `portal`, `api`,
+  `control-plane`)
+- `<name-or-id>`: resource name or UUID
+- `--namespace`: the declarative namespace to assign
+
+Adopt must run before dump when bringing an existing resource under
+declarative management.
+
+## Dump Command Detail
+
+`kongctl dump declarative` exports live Konnect resource state as declarative
+YAML suitable for use with `plan`, `apply`, and `sync`.
+
+```bash
+kongctl dump declarative \
+  --resources=<type> \
+  --filter-name "<name>" \
+  --include-child-resources \
+  --default-namespace <namespace> \
+  -o yaml \
+  --output-file <path>
+```
+
+Key flags:
+
+- `--resources=<type>`: resource type to dump (e.g. `portal`, `api`,
+  `control_planes`)
+- `--filter-name "<name>"`: scope to a single resource by name
+- `--filter-id "<uuid>"`: scope to a single resource by ID
+- `--include-child-resources`: include nested child resources
+- `--default-namespace <ns>`: add `_defaults.kongctl.namespace` block to
+  output
+- `--output-file <path>`: write output to a file instead of stdout
+- `-o yaml`: output format (yaml is standard for declarative config)
+
+Output behavior:
+
+- `ref` values default to the resource UUID. Replace with human-friendly
+  names during integration.
+- `KONGCTL-namespace` labels are filtered from output by design.
+- `--default-namespace` adds a `_defaults.kongctl` block rather than
+  per-resource `kongctl` metadata.
+
+## Plan Modes
+
+- `--mode apply`: Create and update only.
+- `--mode sync`: Create, update, and delete missing resources.
+- `--mode delete`: Plan only deletions for matching input scope.
+
+`kongctl delete` is a convenience wrapper around declarative delete planning
+and execution.
+
+## Common Flags
+
+- `--recursive`: load all YAML files in a directory tree. Use when `-f`
+  points to a directory containing only kongctl declarative resource files.
+  Non-resource YAML (specs, docs, etc.) in the tree will cause parse errors.
+  When non-resource files coexist, use multiple `-f` flags instead:
+  `kongctl diff -f resources/apis.yaml -f resources/portals.yaml --mode apply`
+- `--base-dir <path>`: set the root for `!file` path resolution. Required
+  when `!file` tags reference files outside the `-f` directory. Use an
+  absolute path — relative values resolve from the config file directory,
+  not cwd (e.g. `--base-dir "$(pwd)"`).
+
+## Output and Approval
+
+- Mutating commands (`apply`, `sync`, `delete`) with `-o json` or `-o yaml`
+  require `--auto-approve` or `--dry-run` because interactive confirmation
+  is not available with structured output.
+- Use `-o text` for interactive runs that prompt for confirmation.
+- Use `-o json --auto-approve` for non-interactive or scripted execution.
+
+## Safety Defaults
+
+- Prefer `--dry-run` for `apply`, `sync`, and `delete` before execution.
+- Use `--require-any-namespace` or `--require-namespace` as guardrails.
+- Set explicit output with `-o <text|json|yaml>`.
+- Use `--profile <name>` when environment separation matters.
+
+## Command Discovery
+
+When syntax is uncertain, check help text:
+
+```bash
+kongctl explain --help
+kongctl scaffold --help
+kongctl plan --help
+kongctl diff --help
+kongctl apply --help
+kongctl sync --help
+kongctl delete --help
+kongctl dump declarative --help
+kongctl adopt --help
+deck file openapi2kong --help
+deck file patch --help
+deck file add-plugins --help
+deck file add-tags --help
+```

--- a/.kongctl/skills/kongctl-declarative/references/deck-gateway.md
+++ b/.kongctl/skills/kongctl-declarative/references/deck-gateway.md
@@ -1,0 +1,156 @@
+# decK Gateway Integration
+
+Use this file when the user wants Kong Gateway runtime configuration:
+services, routes, plugins, consumers, upstreams, or Gateway config generated
+from OpenAPI. kongctl manages Konnect SaaS resources; decK manages Kong
+Gateway state. Combine them with `control_planes[]._deck`.
+
+## Decision Rule
+
+- Use kongctl `apis`, `portals`, and `api.versions` for API catalog,
+  portal publication, and spec storage in Konnect.
+- Use decK state files for Gateway services, routes, plugins, consumers,
+  consumer groups, upstreams, targets, and other runtime entities.
+- Use both when an OpenAPI spec should appear in the Konnect API catalog
+  and configure an actual Gateway route/service/plugin implementation.
+
+## Preconditions
+
+- Confirm decK is installed: `deck version`.
+- For CI, install both tools:
+  - `kong/setup-kongctl@v1`
+  - `kong/setup-deck@v1`
+- Use `deck file ... --help` for APIOps helper syntax when uncertain.
+
+## `_deck` Integration Pattern
+
+Declare `_deck` on a control plane. kongctl runs decK once per control plane
+that declares `_deck`, then resolves external gateway services by selector.
+
+```yaml
+control_planes:
+  - ref: example-cp
+    name: 'example-cp'
+    cluster_type: 'CLUSTER_TYPE_SERVERLESS_V1'
+    _deck:
+      files:
+        - 'gateway.yaml'
+      flags:
+        - '--analytics=false'
+
+    gateway_services:
+      - ref: example-gw-svc
+        _external:
+          selector:
+            matchFields:
+              name: 'example-service'
+
+apis:
+  - ref: example-api
+    name: 'Example API'
+    implementations:
+      - ref: example-api-impl
+        service:
+          control_plane_id: !ref example-cp#id
+          id: !ref example-gw-svc#id
+```
+
+Rules:
+
+- `_deck` is allowed only on `control_planes`.
+- `_deck.files` must include at least one decK state file.
+- `_deck.flags` may contain extra decK flags, but not Konnect auth or output
+  flags. Do not set `--konnect-token`, `--konnect-control-plane-name`,
+  `--konnect-addr`, `--json-output`, or `--output`; kongctl injects those.
+- Relative `_deck.files` paths resolve from the kongctl config file that
+  declares `_deck`, and must stay inside the `--base-dir` boundary.
+- `gateway_services` that point at decK-created services must use
+  `_external.selector.matchFields.name`; match the service `name` in the
+  decK state file.
+- In `plan`/`diff`, kongctl runs `deck gateway diff`. In `apply`, kongctl
+  runs `deck gateway apply`. In `sync`, kongctl runs `deck gateway sync`.
+
+## decK State File Requirements
+
+Always scope decK state before using sync. Include `_info.select_tags` and
+matching `tags` on generated entities so `deck gateway sync` does not delete
+resources owned by other decK files.
+
+```yaml
+_format_version: '3.0'
+
+_info:
+  select_tags:
+    - 'payments'
+
+services:
+  - name: payments-service
+    url: https://payments.example.com
+    tags:
+      - payments
+    routes:
+      - name: payments-route
+        paths:
+          - /payments
+        tags:
+          - payments
+```
+
+## OpenAPI to Gateway APIOps
+
+For prompts like "set up an API Gateway from this OpenAPI spec":
+
+1. Keep the OpenAPI file in its existing repository location.
+2. Generate decK state from the spec:
+   ```bash
+   deck file openapi2kong \
+     --spec <openapi.yaml> \
+     --select-tag <tag> \
+     --output-file <gateway.yaml>
+   ```
+3. Inspect the generated service and route names.
+4. Ensure `_info.select_tags` and entity `tags` match the chosen tag.
+5. Patch operational defaults when needed:
+   ```bash
+   deck file patch \
+     --state <gateway.yaml> \
+     --selector '$..services[*]' \
+     --value 'read_timeout:30000' \
+     --output-file <gateway-patched.yaml>
+   ```
+6. Add plugins when needed:
+   ```bash
+   deck file add-plugins \
+     --state <gateway.yaml> \
+     --selector '$..services[*]' \
+     --config '{"name":"key-auth"}' \
+     --output-file <gateway-plugins.yaml>
+   ```
+7. Add or normalize tags when needed:
+   ```bash
+   deck file add-tags \
+     --state <gateway.yaml> \
+     --selector 'services[*]' \
+     --output-file <gateway-tagged.yaml> \
+     <tag>
+   ```
+8. Add `_deck.files` to the target control plane.
+9. Add `control_planes[].gateway_services` external selectors for any
+   generated Gateway services that Konnect API implementations must reference.
+10. Add `apis[].implementations[].service` with `control_plane_id` pointing
+    to the control plane and `id` pointing to the external gateway service.
+11. Validate with `kongctl diff -f <resources> --mode apply -o text`.
+
+Prefer writing each APIOps command to a new output file, then promote the
+final state file after inspection. When a repository already has scripts for
+OpenAPI-to-decK generation, update those scripts instead of replacing them.
+
+## Repository Example
+
+When working inside the `kongctl` repository, use this concrete example:
+
+- `docs/examples/declarative/deck/control-plane.yaml`
+- `docs/examples/declarative/deck/gateway-services.yaml`
+- `docs/examples/declarative/deck/api.yaml`
+
+The same pattern applies in other repositories even when the paths differ.

--- a/.kongctl/skills/kongctl-declarative/references/resources.md
+++ b/.kongctl/skills/kongctl-declarative/references/resources.md
@@ -1,0 +1,350 @@
+# Declarative Resource Patterns
+
+Use this file as the portable schema reference when the skill is installed
+outside the `kongctl` repository.
+
+## Recommended Layout
+
+```text
+konnect/resources/
+  control-planes.yaml
+  portals.yaml
+  apis.yaml
+```
+
+Match existing repository conventions when a layout already exists.
+Do not require OpenAPI specs to be placed under the declarative resources
+directory.
+
+## Top-Level Resource Keys
+
+- `apis`
+- `audit-logs`
+- `application_auth_strategies`
+- `catalog_services`
+- `control_planes`
+- `dcr_providers`
+- `event_gateways`
+- `gateway_services`
+- `organization` (contains `teams`)
+- `portals`
+
+## Schema-First Authoring
+
+Use `kongctl explain` and `kongctl scaffold` before guessing at resource
+shape. These commands are local schema helpers and do not require Konnect
+authentication.
+
+```bash
+kongctl explain api --extended -o text
+kongctl explain api.publications.portal_id
+kongctl scaffold api
+kongctl scaffold api.versions
+```
+
+Use `explain` to confirm:
+
+- accepted resource aliases and root YAML keys
+- required and recommended fields
+- field types, enum values, tags, and reference kinds
+- whether a child resource can be declared at root level, nested, or both
+- field placement paths for root and nested YAML declarations
+
+Use `scaffold` to generate a commented starter YAML shape. Edit the generated
+placeholder values, then validate with `diff` or `plan`.
+
+Use `dump declarative` when live Konnect state should drive the shape, such as
+adopting an existing resource into declarative management.
+
+## Union and `oneOf` Resources
+
+`kongctl explain <resource-path> -o json` emits JSON Schema. When the schema
+contains `oneOf`, choose exactly one branch.
+
+Common patterns:
+
+- A discriminator field with `const`, such as `strategy_type: key_auth`.
+- A discriminator field with `const`, such as `type: tls_server`.
+- Reference selector alternatives, such as an `id` object or a `name` object.
+
+Do not merge branch-specific fields from multiple options. For example, do not
+combine `configs.key-auth` and `configs.openid-connect` in the same
+`application_auth_strategies` item.
+
+`kongctl scaffold` marks these alternatives with `# oneOf option: ...`. One
+branch is active and the other branches are commented. To switch variants,
+uncomment one whole branch and comment or remove the previously active branch.
+Common fields shown outside the `# oneOf option: ...` blocks apply to all
+variants.
+
+## Parent and Child Rules
+
+- Parent resources support `kongctl` metadata:
+  - `apis`
+  - `catalog_services`
+  - `portals`
+  - `application_auth_strategies`
+  - `control_planes`
+  - `event_gateways`
+- Child resources do not support `kongctl` metadata.
+- Put ownership defaults in `_defaults.kongctl`.
+
+## `_defaults` and Ownership
+
+Use `_defaults` to apply namespace and protected values in one file:
+
+```yaml
+_defaults:
+  kongctl:
+    namespace: team-alpha
+    protected: false
+```
+
+Resource-level `kongctl` values override `_defaults`.
+
+## YAML Tags
+
+- `!file`: Load file content, optionally with extraction.
+- `!ref`: Resolve another resource by `ref`, optionally with `#field`.
+
+Examples:
+
+```yaml
+name: !file <existing-openapi-path>#info.title
+description: !file <existing-openapi-path>#info.description
+portal_id: !ref dev-portal#id
+```
+
+`!file` paths resolve relative to the config file and must remain within the
+`--base-dir` boundary.
+
+## Resource Cheat Sheets
+
+### `control_planes`
+
+Common fields:
+
+- `ref`
+- `name`
+- `description`
+- `cluster_type`
+- `auth_type`
+- `cloud_gateway`
+- `proxy_urls`
+- `labels`
+- `_deck`
+- `_external`
+- `kongctl`
+
+Common child blocks:
+
+- `gateway_services`
+- `data_plane_certificates`
+- `members`
+
+Example:
+
+```yaml
+control_planes:
+  - ref: cp-main
+    name: 'my-control-plane'
+    cluster_type: 'CLUSTER_TYPE_CONTROL_PLANE'
+```
+
+Use `_deck` for control-plane scoped decK Gateway state. Load
+`references/deck-gateway.md` when adding `_deck` or `gateway_services`
+selectors.
+
+### `portals`
+
+Common fields:
+
+- `ref`
+- `name`
+- `display_name`
+- `description`
+- `authentication_enabled`
+- `rbac_enabled`
+- `default_api_visibility`
+- `default_page_visibility`
+- `labels`
+- `kongctl`
+
+Common child blocks:
+
+- `pages`
+- `snippets`
+- `customization`
+- `auth_settings`
+- `custom_domain`
+- `teams`
+- `email_config`
+- `email_templates`
+- `assets`
+
+Example:
+
+```yaml
+portals:
+  - ref: dev-portal
+    name: 'my-dev-portal'
+    display_name: 'My Dev Portal'
+    default_api_visibility: 'private'
+    default_page_visibility: 'private'
+```
+
+### `apis`
+
+Common fields:
+
+- `ref`
+- `name`
+- `description`
+- `version`
+- `slug`
+- `labels`
+- `attributes`
+- `kongctl`
+
+Do not use `apis[].spec_content`; it is not supported in declarative
+configuration. Put specs on `apis[].versions[].spec` or root-level
+`api_versions[].spec`.
+
+Common child blocks:
+
+- `versions`
+- `publications`
+- `implementations`
+- `documents`
+
+Example using OpenAPI:
+
+```yaml
+apis:
+  - ref: payments-api
+    name: !file <existing-openapi-path>#info.title
+    description: !file <existing-openapi-path>#info.description
+    versions:
+      - ref: payments-v1
+        version: !file <existing-openapi-path>#info.version
+        spec: !file <existing-openapi-path>
+    publications:
+      - ref: payments-pub
+        portal_id: !ref dev-portal#id
+        visibility: public
+```
+
+### `gateway_services`
+
+Use `gateway_services` as external selectors for Kong Gateway services created
+by decK. Prefer nesting under the control plane that declares `_deck`.
+
+```yaml
+control_planes:
+  - ref: cp-main
+    name: 'my-control-plane'
+    _deck:
+      files:
+        - 'gateway.yaml'
+    gateway_services:
+      - ref: payments-gw-svc
+        _external:
+          selector:
+            matchFields:
+              name: 'payments-service'
+```
+
+Reference the selected service from API implementations:
+
+```yaml
+apis:
+  - ref: payments-api
+    implementations:
+      - ref: payments-impl
+        service:
+          control_plane_id: !ref cp-main#id
+          id: !ref payments-gw-svc#id
+```
+
+### `application_auth_strategies`
+
+Common fields:
+
+- `ref`
+- `name`
+- `display_name`
+- `strategy_type` (`key_auth` or `openid_connect`)
+- `configs`
+- `labels`
+
+Minimal key-auth example:
+
+```yaml
+application_auth_strategies:
+  - ref: key-auth-main
+    name: 'my-key-auth'
+    display_name: 'My Key Auth'
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-API-Key
+```
+
+### `organization.teams`
+
+Structure:
+
+- `organization`
+- `teams` (array of objects with `ref`, `name`, optional metadata fields)
+
+Example:
+
+```yaml
+organization:
+  teams:
+    - ref: platform-team
+      name: 'Platform Team'
+```
+
+## Reference Linking Patterns
+
+- API publication to portal:
+  - `portal_id: !ref <portal-ref>#id`
+- Publication auth strategy reference:
+  - `auth_strategy_ids: [!ref <auth-strategy-ref>#id]`
+- Child-to-parent references:
+  - prefer `!ref` instead of hard-coded UUIDs
+
+## Schema Discovery Without Local Docs
+
+When field-level uncertainty remains, inspect the local schema first:
+
+```bash
+kongctl explain <resource-path> -o text --extended
+kongctl scaffold <resource-path>
+```
+
+Then sample live Konnect state with dump commands when needed:
+
+```bash
+kongctl dump declarative --resources=portal --include-child-resources -o yaml
+kongctl dump declarative --resources=api --include-child-resources -o yaml
+kongctl dump declarative --resources=control_planes -o yaml
+```
+
+Then adapt generated shape to the target repository layout and naming.
+
+## Validation Loop
+
+```bash
+kongctl diff -f <path> --recursive --mode apply -o text
+```
+
+When `!file` tags reference files outside the `-f` directory, add
+`--base-dir` with the absolute project root path. Relative `--base-dir`
+values resolve from the config file directory, not cwd:
+
+```bash
+kongctl diff -f <path> --recursive --base-dir "$(pwd)" --mode apply -o text
+```

--- a/.kongctl/skills/kongctl-declarative/references/troubleshooting.md
+++ b/.kongctl/skills/kongctl-declarative/references/troubleshooting.md
@@ -1,0 +1,155 @@
+# Declarative Troubleshooting
+
+Use this file for common failures when planning, applying, syncing, deleting,
+dumping, or adopting declarative resources.
+
+## Quick Triage
+
+1. Confirm CLI and auth
+   `kongctl version`
+   `kongctl get organization -o json`
+2. Validate parse and plan scope
+   `kongctl plan -f <path> --mode apply -o json`
+3. Inspect drift intent before destructive execution
+   `kongctl diff -f <path> --mode sync -o text`
+
+## Common Issues
+
+### Parse Errors with `--recursive`
+
+Symptom: `--recursive` fails with parse errors on files that are not
+kongctl declarative resources (e.g. OpenAPI specs, documentation YAML).
+
+Actions:
+
+- Only place kongctl resource files in the resources directory.
+- Keep specs, docs, and other YAML outside the resources directory.
+- If non-resource files cannot be moved, use multiple `-f` flags for
+  individual resource files instead of `--recursive`:
+  `kongctl diff -f resources/apis.yaml -f resources/portals.yaml --mode apply`
+
+### Unknown Field Errors
+
+Symptom: parser rejects a field name.
+
+Actions:
+
+- Run `kongctl explain <resource-path> --extended -o text` to confirm
+  accepted fields and YAML placement.
+- Run `kongctl scaffold <resource-path>` when the whole resource shape is
+  uncertain.
+- Check field patterns in `references/resources.md`.
+- If uncertain, generate live examples with `dump declarative`.
+- Fix common typos like `lables` vs `labels`.
+- Ensure `kongctl` metadata is only on parent resources.
+
+### `!file` Resolution Errors
+
+Symptom: file not found or base-dir boundary violation.
+
+Actions:
+
+- Verify path is relative to the declarative config file.
+- Set an absolute base directory that includes existing spec paths:
+  `kongctl plan -f <path> --base-dir "$(pwd)" --mode apply -o json`
+- Move spec files only when the user explicitly asks to change layout.
+
+### Unexpected Deletes in Sync
+
+Symptom: `sync` plan includes deletes you did not expect.
+
+Actions:
+
+- Re-check with `diff --mode apply` to isolate create/update intent.
+- Restrict scope with `--require-namespace=<ns>`.
+- Use `--dry-run` before executing `sync` or `delete`.
+
+### Unexpected Deletes from decK Sync
+
+Symptom: a plan or sync involving `_deck` shows Gateway deletes outside the
+intended API or service.
+
+Actions:
+
+- Ensure the decK state file has `_info.select_tags`.
+- Ensure generated services, routes, plugins, consumers, and upstreams have
+  matching `tags`.
+- Prefer `deck gateway apply` behavior through `kongctl apply` when you only
+  want create/update behavior.
+- Load `references/deck-gateway.md` before changing `_deck` scope.
+
+### `_deck` Validation Errors
+
+Symptom: parser rejects `_deck` or gateway service selectors.
+
+Actions:
+
+- Put `_deck` only under `control_planes`.
+- Include at least one `_deck.files` entry.
+- Keep `_deck.files` as file paths, not flags.
+- Do not include Konnect auth or output flags in `_deck.flags`; kongctl
+  injects them.
+- Use `_external.selector.matchFields.name` as the only selector field for
+  decK-created `gateway_services`.
+
+### Namespace Label and Adopt Conflicts
+
+Symptom: adopt fails or namespace ownership looks inconsistent.
+
+Actions:
+
+- Read current labels with query commands before adopting.
+- If namespace label already exists, align `_defaults.kongctl.namespace`
+  with the existing owner.
+- Use adopt only for unmanaged resources you intend to manage declaratively.
+
+### Dump Output Missing KONGCTL Labels
+
+Symptom: dumped YAML does not contain `KONGCTL-namespace` labels even though
+the resource was adopted.
+
+This is expected behavior — `dump` filters out KONGCTL metadata labels by
+design. Use `--default-namespace` to add a `_defaults.kongctl` block to the
+output instead.
+
+### Dump Ref Values Are UUIDs
+
+Symptom: dumped `ref` fields contain UUIDs instead of human-friendly names.
+
+This is expected — `dump` uses the resource UUID as the default `ref`. Replace
+UUID refs with meaningful names during integration into the declarative config
+repository.
+
+### Drift After Adopt and Dump
+
+Symptom: `diff` shows unexpected changes after integrating dumped config.
+
+Actions:
+
+- Ensure adopt ran before dump so the resource is labeled.
+- Run `kongctl get <resource-type> <name> -o json` to compare live state
+  against the dumped config.
+- Check that `_defaults.kongctl.namespace` in the config matches the
+  namespace used in the adopt command.
+
+### Output or Profile Confusion
+
+Symptom: output format or target account is unexpected.
+
+Actions:
+
+- Set explicit output: `-o text`, `-o json`, or `-o yaml`.
+- Set explicit profile: `--profile <name>`.
+- Inspect environment overrides:
+  `env | grep '^KONGCTL_'`
+
+### API/Auth/Network Failures
+
+Symptom: plan or execution fails with auth or transport errors.
+
+Actions:
+
+- Re-authenticate with `kongctl login` or set `KONGCTL_DEFAULT_KONNECT_PAT`.
+- Verify region/base URL configuration.
+- Re-run with diagnostics:
+  `--log-level debug` or `--log-level trace`

--- a/.kongctl/skills/kongctl-extension-builder/SKILL.md
+++ b/.kongctl/skills/kongctl-extension-builder/SKILL.md
@@ -1,0 +1,352 @@
+---
+description: Scaffold and maintain kongctl CLI extensions. Use when a user wants to create a script or Go extension, define extension command paths, use the kongctl Go SDK helper, test install/link workflows, or debug extension context handling.
+license: Apache-2.0
+metadata:
+  category: extensions
+  product: kongctl
+  version: 1.2.1
+name: kongctl-extension-builder
+---
+
+# kongctl extension builder
+
+## Goal
+
+Help users create a runnable `kongctl` CLI extension with a valid
+`kongctl-extension.yaml`, an executable runtime, and local and remote test
+workflows.
+
+## Core Rules
+
+- Extensions run as separate processes; do not import `internal/...` packages
+  from `kongctl`.
+- The manifest file must be named `kongctl-extension.yaml`.
+- Required manifest fields are:
+  - `schema_version: 1`
+  - `publisher`
+  - `name`
+  - `runtime.command`
+  - at least one `command_paths[].path`
+- Extension IDs use `publisher/name`, and both segments should be lowercase
+  path-safe identifiers.
+- v1 command paths may contribute below `get` or `list`, or define a custom
+  root verb that does not collide with built-ins.
+- Built-in root segments such as `get` and `list` cannot declare aliases.
+- `runtime.command` must be relative to the extension root and already
+  executable. `kongctl` does not compile source during install.
+- `version` in `kongctl-extension.yaml` is optional. For remotely installed
+  extensions, prefer Git tags/releases as the package version source; kongctl
+  displays the release tag, ref, or short commit when the manifest omits a
+  version.
+- GitHub repository names do not need a `kongctl-*` prefix. Use names that are
+  clear for humans and keep the manifest ID in `publisher/name` form.
+- Extension-specific args and flags should be shown directly in examples, such
+  as `kongctl get foo --limit 10`. Use `--` only as an escape hatch when an
+  extension needs to receive a token that collides with a host `kongctl` flag,
+  such as `--output`, `--profile`, `--help`, or their shorthands.
+- For Go extensions, prefer `github.com/kong/kongctl/pkg/sdk` over hand-rolled
+  context parsing. Use it to load the runtime context, create an authenticated
+  `sdk-konnect-go` client, run reentrant `kongctl` commands, and render output
+  with parent `--output` and `--jq` settings.
+- Do not make Go extensions call `kongctl api` as the primary Konnect access
+  path when typed SDK access is appropriate. Use reentrant `kongctl` only for
+  script extensions, debugging, or commands that are easier to delegate back to
+  the host.
+- Put extension diagnostics on stderr when stdout needs to preserve structured
+  output from a reentrant `kongctl` command.
+
+## Workflow
+
+1. Choose a runtime style:
+   - shell script for small wrappers
+   - Go binary for richer parsing or reusable logic
+2. Create `kongctl-extension.yaml` with one or more command paths.
+3. Add the runtime file named by `runtime.command`.
+4. Make script runtimes executable with `chmod +x`.
+5. Test with a development link:
+   ```sh
+   kongctl link extension <extension-dir>
+   kongctl get extension <publisher>/<name>
+   kongctl get <resource>
+   ```
+6. Use local install when testing managed package copying:
+   ```sh
+   kongctl install extension <extension-dir>
+   kongctl list extensions
+   kongctl uninstall extension <publisher>/<name>
+   ```
+7. Prepare remote repositories so install can consume release archives:
+   - release archives are preferred over source clone fallback
+   - `kongctl-extension.yaml` must be at the archive root
+   - `runtime.command` points to a runnable file inside the archive
+   - publish one archive asset per release, or include the target platform in
+     each platform-specific asset name
+   - use `.tar.gz` for Go binary releases because it preserves executable bits
+     reliably
+   ```sh
+   kongctl install extension <owner>/<repo>
+   kongctl install extension <owner>/<repo> --ref <branch-or-tag>
+   kongctl install extension <owner>/<repo>@<tag>
+   kongctl install extension <owner>/<repo>@<tag> --yes
+   kongctl upgrade extension <publisher>/<name>
+   kongctl upgrade extension <owner>/<repo>
+   kongctl upgrade extension <publisher>/<name>@<tag-or-version> --yes
+   kongctl upgrade extension
+   kongctl upgrade extensions
+   ```
+
+When no compatible release archive exists, `kongctl install extension
+<owner>/<repo>` falls back to cloning the repository. Source fallback is only
+valid when the repository root already contains `kongctl-extension.yaml` and an
+already-runnable script or binary referenced by `runtime.command`.
+
+For release-artifact installs, `kongctl upgrade extension <publisher>/<name>`
+or `kongctl upgrade extension <owner>/<repo>` selects the latest compatible
+GitHub release asset from the originally recorded repository. Add
+`@<tag-or-version>` to pin the upgrade target, for example
+`kongctl upgrade extension kong/debug@0.2.0` or
+`kongctl upgrade extension kong/kongctl-ext-debug@0.2.0`. A bare semantic
+version tries the exact release tag first and then a `v`-prefixed tag.
+Source-clone installs require an explicit `@<tag|ref|commit>` target because
+there is no stable "latest" release asset to resolve.
+
+`kongctl upgrade extension` and `kongctl upgrade extensions` without a selector
+upgrade all installed GitHub release-asset extensions. Linked extensions, local
+path installs, and GitHub source-clone installs are skipped in batch mode.
+
+Remote installs show a trust warning prompt with the selected source, extension
+name, asset or ref, executable, command paths, and package/manifest/executable
+hashes. Use `--yes` for automated tests or release workflow verification.
+
+## Minimal Manifest
+
+```yaml
+schema_version: 1
+
+publisher: kong
+name: foo
+
+runtime:
+  command: kongctl-ext-foo
+
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+        aliases: [foos]
+```
+
+## Script Runtime Pattern
+
+Use shell for lightweight wrappers and debugging helpers.
+
+```sh
+#!/bin/sh
+set -eu
+
+echo "context_path=${KONGCTL_EXTENSION_CONTEXT:-}" >&2
+
+kongctl_bin="kongctl"
+if [ -n "${KONGCTL_EXTENSION_CONTEXT:-}" ] &&
+  [ -r "$KONGCTL_EXTENSION_CONTEXT" ]; then
+  kongctl_bin=$(sed -n \
+    's/^[[:space:]]*"kongctl_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$KONGCTL_EXTENSION_CONTEXT")
+fi
+
+"$kongctl_bin" api get /v2/control-planes
+```
+
+## Go Runtime Pattern
+
+Use Go when argument parsing, typed Konnect access, JSON handling, or richer
+errors matter. Import the public kongctl SDK helper, never
+`github.com/kong/kongctl/internal/...`.
+
+```go
+import "github.com/kong/kongctl/pkg/sdk"
+```
+
+`pkg/sdk` provides:
+
+- `sdk.LoadRuntimeContextFromEnv()`
+- `runtimeCtx.Args()` for extension-specific args after host flags are removed
+- `runtimeCtx.DataDir()` for extension-owned persistent files
+- `runtimeCtx.KonnectSDK(ctx)` for an authenticated `sdk-konnect-go` client
+- `runtimeCtx.Output().Render(display, raw)` for native output and jq behavior
+- `runtimeCtx.RunKongctl(ctx, args...)` for deliberate reentrant host calls
+
+Use this shape for Go runtimes:
+
+```go
+func run() error {
+    runtimeCtx, err := sdk.LoadRuntimeContextFromEnv()
+    if err != nil {
+        return err
+    }
+
+    ctx := context.Background()
+    konnect, err := runtimeCtx.KonnectSDK(ctx)
+    if err != nil {
+        return fmt.Errorf("create Konnect SDK client: %w", err)
+    }
+
+    res, err := konnect.Me.GetUsersMe(ctx)
+    if err != nil {
+        return fmt.Errorf("get current user: %w", err)
+    }
+
+    display := map[string]any{
+        "profile": runtimeCtx.Resolved.Profile,
+        "user":    res.GetUser(),
+    }
+    return runtimeCtx.Output().Render(display, res.GetUser())
+}
+```
+
+For `Render(display, raw)`, text output uses `display`; JSON/YAML and jq use
+`raw`. When raw is omitted, the display value is used for all formats. Keep
+stdout for command data and send diagnostics to stderr.
+
+For a dedicated Go extension repository, use a normal module:
+
+```sh
+go mod init github.com/<owner>/<repo>
+go get github.com/kong/kongctl@<released-version>
+go mod tidy
+```
+
+While developing against an unreleased local kongctl checkout, use a temporary
+replace directive:
+
+```go
+replace github.com/kong/kongctl => /path/to/kongctl
+```
+
+Remove local replace directives before publishing release artifacts unless the
+repository intentionally vendors or pins an internal development checkout.
+Commit `go.sum` for Go extension repositories.
+
+## Release Artifact Workflow
+
+For GitHub installs, prefer a release artifact that extracts to this shape:
+
+```text
+kongctl-extension.yaml
+bin/kongctl-ext-foo
+README.md
+```
+
+With:
+
+```yaml
+runtime:
+  command: bin/kongctl-ext-foo
+```
+
+For a Go extension, add a workflow like this and adjust the binary package path
+and artifact names for the repository:
+
+```yaml
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: mkdir -p dist/package/bin
+      - run: |
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -o dist/package/bin/kongctl-ext-foo ./cmd/kongctl-ext-foo
+          cp kongctl-extension.yaml README.md dist/package/
+          chmod +x dist/package/bin/kongctl-ext-foo
+          archive="dist/kongctl-ext-foo-${{ matrix.goos }}-"
+          archive="${archive}${{ matrix.goarch }}.tar.gz"
+          tar -C dist/package -czf "$archive" \
+            kongctl-extension.yaml README.md bin/kongctl-ext-foo
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.tar.gz
+```
+
+For a script extension, publish a single universal archive:
+
+```sh
+mkdir -p dist/package/bin
+cp kongctl-extension.yaml README.md dist/package/
+cp kongctl-ext-foo dist/package/bin/
+chmod +x dist/package/bin/kongctl-ext-foo
+tar -C dist/package -czf dist/kongctl-ext-foo-universal.tar.gz \
+  kongctl-extension.yaml README.md bin/kongctl-ext-foo
+```
+
+The installer accepts `.tar.gz`, `.tgz`, and `.zip` assets. If a release has
+more than one archive asset, platform-specific assets should include the current
+`GOOS` and `GOARCH` in the name, such as
+`kongctl-ext-foo-linux-amd64.tar.gz`.
+
+## Runtime Context
+
+When an extension runs, `kongctl` sets `KONGCTL_EXTENSION_CONTEXT` to a
+generated `context.json` file. Read this file for:
+
+- matched command path
+- remaining extension arguments
+- selected profile
+- resolved base URL
+- output, jq, color theme, and log settings
+- extension data directory
+- host `kongctl` path and version
+
+Never expect secrets in `context.json`. Go extensions should use
+`github.com/kong/kongctl/pkg/sdk` when they need a configured Konnect client or
+native output rendering. Script extensions can invoke `kongctl api` or other
+built-in commands as subprocesses when they need host-authenticated Konnect
+calls. Child `kongctl` commands inherit the parent extension context unless
+they explicitly override flags such as `--profile`, `--output`, or
+`--base-url`.
+
+## Good Educational Extension Ideas
+
+- Debug context: print `context.json`, remaining args, and reentrant command
+  behavior.
+- Who am I: call `kongctl get me` and render the current user in the parent
+  output format.
+- Go current user: use `pkg/sdk` to create a Konnect client and render
+  `sdk-konnect-go` results with parent output settings.
+- Control plane summary: call `kongctl api` to list control planes and print a
+  compact operational summary.
+- Portal/API report: combine a few `kongctl api` calls into a read-only report
+  that would be awkward as a one-liner.
+- Declarative helper: wrap existing `kongctl plan`, `diff`, or `apply` command
+  sequences for a team-specific workflow.
+
+Prefer read-only examples for public educational repositories. They are easier
+to try safely and demonstrate auth/context reuse without destructive setup.
+
+## Examples
+
+- Script extension: `docs/examples/extensions/script`
+- Go extension: `docs/examples/extensions/go`
+
+The Go example must be built before linking because install and link expect
+`runtime.command` to point to an existing executable.

--- a/.kongctl/skills/kongctl-extension-builder/agents/openai.yaml
+++ b/.kongctl/skills/kongctl-extension-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Kongctl Extension Builder'
+  short_description: 'Create and test kongctl CLI extensions'
+  default_prompt: 'Help create a kongctl CLI extension with a valid kongctl-extension.yaml, runnable runtime, and link/install test workflow.'


### PR DESCRIPTION
## 概要

kongctl CLI でインストールしたスキル一式を追加します。`feature/keycloak-sso` ブランチの作業とは無関係なため、独立した PR として切り出しました。

## 変更内容

- `.kongctl/skills/` — kongctl がインストールしたスキル本体
  - `kongctl-declarative`（宣言型設定の管理）
  - `kongctl-extension-builder`（CLI 拡張のスキャフォールド）
  - `.kongctl-skills-manifest.json`（インストールマニフェスト）
- `.agents/skills/` — 上記スキルへのシンボリックリンク（エージェント用ディスカバリパス）

## 備考

- 自動生成・インストールされたスキル定義のみで、アプリケーションコードへの変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)