### PR TITLE
refactor: 環境変数 CONTROL_PLANE_ID を PREFIX にリネーム

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ MYSQL_PORT=3306
 KAFKA_BROKER=kafka:9092
 
 # Kong
-CONTROL_PLANE_ID=<your-control-plane-id>
+PREFIX=<your-control-plane-id>
 EVENT_GATEWAY_CP_ID=<your-event-gateway-cp-id>
 DECK_KONNECT_CONTROL_PLANE_NAME=<your-control-plane-name>
 DECK_OPENAI_API_KEY=<your-openai-api-key>

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ MYSQL_PORT=3306
 KAFKA_BROKER=kafka:9092
 
 # Kong
-PREFIX=<your-control-plane-id>
+# Konnect エンドポイントのプレフィックス（例: 4fa752f311 → 4fa752f311.us.cp.konghq.com）
+PREFIX=<your-konnect-endpoint-prefix>
 EVENT_GATEWAY_CP_ID=<your-event-gateway-cp-id>
 DECK_KONNECT_CONTROL_PLANE_NAME=<your-control-plane-name>
 DECK_OPENAI_API_KEY=<your-openai-api-key>

--- a/README.en.md
+++ b/README.en.md
@@ -46,7 +46,7 @@ Open `.env` and configure the following values for your environment:
 
 | Variable                          | Description                            | Example                                |
 | --------------------------------- | -------------------------------------- | -------------------------------------- |
-| `CONTROL_PLANE_ID`                | Konnect control plane ID               | `xxxxxxxx-xxxx-...`                    |
+| `PREFIX`                          | Konnect control plane ID               | `xxxxxxxx-xxxx-...`                    |
 | `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway control plane ID | `xxxxxxxx-xxxx-...`                    |
 | `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect control plane name             | `my-control-plane`                     |
 | `DECK_OPENAI_API_KEY`             | OpenAI API key (for AI Gateway)        | `sk-...`                               |

--- a/README.en.md
+++ b/README.en.md
@@ -44,15 +44,15 @@ cp .env.example .env
 
 Open `.env` and configure the following values for your environment:
 
-| Variable                          | Description                            | Example                                |
-| --------------------------------- | -------------------------------------- | -------------------------------------- |
-| `PREFIX`                          | Konnect control plane ID               | `xxxxxxxx-xxxx-...`                    |
-| `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway control plane ID | `xxxxxxxx-xxxx-...`                    |
-| `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect control plane name             | `my-control-plane`                     |
-| `DECK_OPENAI_API_KEY`             | OpenAI API key (for AI Gateway)        | `sk-...`                               |
-| `AUTH_SECRET`                     | NextAuth session encryption key        | generate via `openssl rand -base64 32` |
-| `AUTH_KEYCLOAK_ID`                | Keycloak client ID                     | `jungle-store-frontend`                |
-| `AUTH_KEYCLOAK_SECRET`            | Keycloak client secret                 | (issued by Keycloak)                   |
+| Variable                          | Description                                           | Example                                |
+| --------------------------------- | ----------------------------------------------------- | -------------------------------------- |
+| `PREFIX`                          | Konnect endpoint prefix (`<prefix>.us.cp.konghq.com`) | `4fa752f311`                           |
+| `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway control plane ID                | `xxxxxxxx-xxxx-...`                    |
+| `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect control plane name                            | `my-control-plane`                     |
+| `DECK_OPENAI_API_KEY`             | OpenAI API key (for AI Gateway)                       | `sk-...`                               |
+| `AUTH_SECRET`                     | NextAuth session encryption key                       | generate via `openssl rand -base64 32` |
+| `AUTH_KEYCLOAK_ID`                | Keycloak client ID                                    | `jungle-store-frontend`                |
+| `AUTH_KEYCLOAK_SECRET`            | Keycloak client secret                                | (issued by Keycloak)                   |
 
 Other variables (MySQL, Kafka, service URLs, Keycloak URLs/realm, etc.) work with their default values.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cp .env.example .env
 
 | 変数名                            | 説明                                          | 例                               |
 | --------------------------------- | --------------------------------------------- | -------------------------------- |
-| `CONTROL_PLANE_ID`                | Konnect コントロールプレーン ID               | `xxxxxxxx-xxxx-...`              |
+| `PREFIX`                          | Konnect コントロールプレーン ID               | `xxxxxxxx-xxxx-...`              |
 | `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway コントロールプレーン ID | `xxxxxxxx-xxxx-...`              |
 | `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect コントロールプレーン名                | `my-control-plane`               |
 | `DECK_OPENAI_API_KEY`             | OpenAI API キー（AI Gateway 用）              | `sk-...`                         |

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ cp .env.example .env
 
 `.env` を開き、以下の値を自分の環境に合わせて設定してください:
 
-| 変数名                            | 説明                                          | 例                               |
-| --------------------------------- | --------------------------------------------- | -------------------------------- |
-| `PREFIX`                          | Konnect コントロールプレーン ID               | `xxxxxxxx-xxxx-...`              |
-| `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway コントロールプレーン ID | `xxxxxxxx-xxxx-...`              |
-| `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect コントロールプレーン名                | `my-control-plane`               |
-| `DECK_OPENAI_API_KEY`             | OpenAI API キー（AI Gateway 用）              | `sk-...`                         |
-| `AUTH_SECRET`                     | NextAuth のセッション暗号鍵                   | `openssl rand -base64 32` で生成 |
-| `AUTH_KEYCLOAK_ID`                | Keycloak クライアント ID                      | `jungle-store-frontend`          |
-| `AUTH_KEYCLOAK_SECRET`            | Keycloak クライアントシークレット             | （Keycloak で発行）              |
+| 変数名                            | 説明                                                                  | 例                               |
+| --------------------------------- | --------------------------------------------------------------------- | -------------------------------- |
+| `PREFIX`                          | Konnect エンドポイントのプレフィックス（`<prefix>.us.cp.konghq.com`） | `4fa752f311`                     |
+| `EVENT_GATEWAY_CP_ID`             | Konnect Event Gateway コントロールプレーン ID                         | `xxxxxxxx-xxxx-...`              |
+| `DECK_KONNECT_CONTROL_PLANE_NAME` | Konnect コントロールプレーン名                                        | `my-control-plane`               |
+| `DECK_OPENAI_API_KEY`             | OpenAI API キー（AI Gateway 用）                                      | `sk-...`                         |
+| `AUTH_SECRET`                     | NextAuth のセッション暗号鍵                                           | `openssl rand -base64 32` で生成 |
+| `AUTH_KEYCLOAK_ID`                | Keycloak クライアント ID                                              | `jungle-store-frontend`          |
+| `AUTH_KEYCLOAK_SECRET`            | Keycloak クライアントシークレット                                     | （Keycloak で発行）              |
 
 その他の変数（MySQL, Kafka, サービス URL, Keycloak の URL/realm 等）はデフォルト値のままで動作します。
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -159,10 +159,10 @@ services:
       KONG_DATABASE: off
       KONG_VITALS: off
       KONG_CLUSTER_MTLS: pki
-      KONG_CLUSTER_CONTROL_PLANE: ${CONTROL_PLANE_ID:-}.us.cp.konghq.com:443
-      KONG_CLUSTER_SERVER_NAME: ${CONTROL_PLANE_ID:-}.us.cp.konghq.com
-      KONG_CLUSTER_TELEMETRY_ENDPOINT: ${CONTROL_PLANE_ID:-}.us.tp.konghq.com:443
-      KONG_CLUSTER_TELEMETRY_SERVER_NAME: ${CONTROL_PLANE_ID:-}.us.tp.konghq.com
+      KONG_CLUSTER_CONTROL_PLANE: ${PREFIX:-}.us.cp.konghq.com:443
+      KONG_CLUSTER_SERVER_NAME: ${PREFIX:-}.us.cp.konghq.com
+      KONG_CLUSTER_TELEMETRY_ENDPOINT: ${PREFIX:-}.us.tp.konghq.com:443
+      KONG_CLUSTER_TELEMETRY_SERVER_NAME: ${PREFIX:-}.us.tp.konghq.com
       KONG_CLUSTER_CERT: /etc/kong/cluster-certs/cluster.crt
       KONG_CLUSTER_CERT_KEY: /etc/kong/cluster-certs/cluster.key
       KONG_LUA_SSL_TRUSTED_CERTIFICATE: system
@@ -180,7 +180,7 @@ services:
       - 8000:8000
       - 8100:8100
     volumes:
-      - ./certs:/etc/kong/cluster-certs
+      - ./certs/kong-gateway:/etc/kong/cluster-certs
     healthcheck:
       test: ['CMD', 'kong', 'health']
       interval: 10s
@@ -198,8 +198,6 @@ services:
       user-service:
         condition: service_healthy
       keycloak:
-        # openid-connect は JWKS を遅延取得するため起動順だけ保証すれば十分。
-        # ヘルスチェックの環境差で全体がブロックしないよう service_started にする。
         condition: service_started
 
   event-gateway:
@@ -249,8 +247,6 @@ services:
   # ============================================================
   # Observability
   # ============================================================
-  # Collector + Tempo + Prometheus + Loki + Grafana を 1 コンテナに集約。
-  # Collector 設定のみ上書きして既存の filter/traces フィルタを保持する。
   otel-lgtm:
     <<: *default
     container_name: otel-lgtm

--- a/compose.yaml
+++ b/compose.yaml
@@ -180,7 +180,7 @@ services:
       - 8000:8000
       - 8100:8100
     volumes:
-      - ./certs/kong-gateway:/etc/kong/cluster-certs
+      - ./certs:/etc/kong/cluster-certs
     healthcheck:
       test: ['CMD', 'kong', 'health']
       interval: 10s
@@ -198,6 +198,8 @@ services:
       user-service:
         condition: service_healthy
       keycloak:
+        # openid-connect は JWKS を遅延取得するため起動順だけ保証すれば十分。
+        # ヘルスチェックの環境差で全体がブロックしないよう service_started にする。
         condition: service_started
 
   event-gateway:
@@ -247,6 +249,8 @@ services:
   # ============================================================
   # Observability
   # ============================================================
+  # Collector + Tempo + Prometheus + Loki + Grafana を 1 コンテナに集約。
+  # Collector 設定のみ上書きして既存の filter/traces フィルタを保持する。
   otel-lgtm:
     <<: *default
     container_name: otel-lgtm


### PR DESCRIPTION
## 概要

Konnect エンドポイントのサブドメイン部分（`<prefix>.us.cp.konghq.com` 等）を指す環境変数 `CONTROL_PLANE_ID` を、より汎用的な `PREFIX` にリネームします。

## 変更内容

- `.env.example`: `CONTROL_PLANE_ID` → `PREFIX`
- `compose.yaml`: Kong の `KONG_CLUSTER_CONTROL_PLANE` / `KONG_CLUSTER_SERVER_NAME` / `KONG_CLUSTER_TELEMETRY_ENDPOINT` / `KONG_CLUSTER_TELEMETRY_SERVER_NAME` の参照を `${PREFIX:-}` に更新
- `README.md` / `README.en.md`: 環境変数表の変数名を更新

## 補足

`EVENT_GATEWAY_CP_ID` と `DECK_KONNECT_CONTROL_PLANE_NAME` は別の変数のため変更していません。リポジトリ全体を grep し、`CONTROL_PLANE_ID` の残存参照がないことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)