### PR TITLE
refactor: Kong Gateway のクラスタ証明書を certs/kong-gateway/ に集約

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -58,7 +58,7 @@ Other variables (MySQL, Kafka, service URLs, Keycloak URLs/realm, etc.) work wit
 
 ### Kong Konnect Certificates
 
-Place your Konnect control plane cluster certificates in the `certs/` directory.
+Place your Konnect control plane cluster certificates under `certs/kong-gateway/` (for Kong Gateway) and `certs/event-gateway/` (for Event Gateway), each containing `cluster.crt` / `cluster.key`.
 
 ### Keycloak (end-user authentication)
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cp .env.example .env
 
 ### Kong Konnect 証明書
 
-Konnect コントロールプレーンのクラスタ証明書を `certs/` ディレクトリに配置してください。
+Konnect コントロールプレーンのクラスタ証明書を、Kong Gateway 用は `certs/kong-gateway/`、Event Gateway 用は `certs/event-gateway/` に配置してください（各ディレクトリに `cluster.crt` / `cluster.key`）。
 
 ### Keycloak（エンドユーザー認証）
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -180,7 +180,7 @@ services:
       - 8000:8000
       - 8100:8100
     volumes:
-      - ./certs:/etc/kong/cluster-certs
+      - ./certs/kong-gateway:/etc/kong/cluster-certs
     healthcheck:
       test: ['CMD', 'kong', 'health']
       interval: 10s


### PR DESCRIPTION
## 概要

Kong Gateway のクラスタ証明書のマウント元を `./certs` から `./certs/kong-gateway` に移し、既存の `./certs/event-gateway`（Event Gateway 用）と対称なディレクトリ構成にします。

## 変更内容

- `compose.yaml`: `kong` サービスの volume を `./certs:/etc/kong/cluster-certs` → `./certs/kong-gateway:/etc/kong/cluster-certs` に変更（`event-gateway` は据え置き）
- `README.md` / `README.en.md`: 証明書の配置手順を「Kong Gateway 用は `certs/kong-gateway/`、Event Gateway 用は `certs/event-gateway/`」に更新

## ⚠️ マージ後に必要な作業

`certs/` は `.gitignore` 対象で証明書実体はリポジトリに含まれません。このブランチを使う各環境で、既存の `certs/cluster.crt` / `certs/cluster.key` を **`certs/kong-gateway/` へ移動**してください。移動しないと Kong が証明書を読めず起動に失敗します。

## スコープ

環境変数リネーム（PREFIX、#32）やネットワーク設定の変更とは独立した certs 再編のみの PR です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)