### PR TITLE
fix: Event Gateway イメージのバージョンを 1.2.0 に固定

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -196,7 +196,7 @@ services:
   event-gateway:
     <<: *default
     container_name: event-gateway
-    image: kong/kong-event-gateway:latest
+    image: kong/kong-event-gateway:1.2.0
     environment:
       # see: https://developer.konghq.com/event-gateway/configuration/
       KONNECT_REGION: us


### PR DESCRIPTION
## 概要

`kong/kong-event-gateway` をこれまで `latest` で運用していたため、上流の非決定的な更新でデモ環境が壊れるリスクがあった。バージョンを `1.2.0` に固定する。

## 変更内容

- `compose.yaml`: `kong/kong-event-gateway:latest` → `kong/kong-event-gateway:1.2.0`

## 備考

Dev Portal ロゴ差し替え（#41）に続く変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)