### PR TITLE
fix: 認証ライフサイクルをKeycloakトークンに追従させる

### DIFF
--- a/services/frontend/src/app/login/page.tsx
+++ b/services/frontend/src/app/login/page.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { signIn, useSession } from 'next-auth/react'
+import { signIn } from 'next-auth/react'
+import { useAuthUser } from '@/lib/auth'
 import Nav from '@/components/Nav'
 
 export default function LoginPage() {
   const router = useRouter()
-  const { status } = useSession()
+  // useAuthUser は RefreshTokenError のセッションを unauthenticated として扱うため、
+  // 失効ユーザーが /login に来ても / へ跳ね返さず再ログインできる。
+  const { status } = useAuthUser()
 
   // 既にログイン済みならトップへ
   useEffect(() => {

--- a/services/frontend/src/auth.ts
+++ b/services/frontend/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth, { customFetch } from 'next-auth'
 import Keycloak from 'next-auth/providers/keycloak'
 import { createKeycloakFetch } from '@/lib/keycloak-fetch'
+import { isAccessTokenValid, refreshAccessToken } from '@/lib/token-refresh'
 
 // フロントチャネル（ブラウザ）とバックチャネル（コンテナ）で Keycloak の到達 URL を分離する。
 //   - issuer: token の iss / 認可エンドポイントに使う「ブラウザが到達する」URL（localhost:8081）。
@@ -18,6 +19,9 @@ const internalUrl = process.env.KEYCLOAK_INTERNAL_URL ?? 'http://keycloak:8081'
 // 公開オリジン宛のサーバー側リクエストだけ内部オリジンへ書き換える fetch。
 const keycloakFetch = createKeycloakFetch(publicUrl, internalUrl)
 
+// リフレッシュはサーバー(コンテナ)→ Keycloak の直接通信なので内部 URL を使う。
+const tokenEndpoint = `${internalUrl}/realms/${realm}/protocol/openid-connect/token`
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,
   providers: [
@@ -30,17 +34,37 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     }),
   ],
   callbacks: {
-    // Kong へ渡す access_token のみをセッショントークンへ引き継ぐ
+    // アクセストークンのライフサイクルを Keycloak に追従させる。
     async jwt({ token, account, profile }) {
+      // 初回サインイン: account からトークン一式を取り込む
       if (account) {
         token.accessToken = account.access_token
+        token.refreshToken = account.refresh_token
+        token.expiresAt = account.expires_at // エポック秒
+        token.error = undefined
+        if (profile?.sub) token.sub = profile.sub
+        return token
       }
-      if (profile?.sub) token.sub = profile.sub
-      return token
+      // 有効期限内ならそのまま
+      if (isAccessTokenValid(token)) return token
+      // 失効: refresh_token で更新（不能なら error が立ち session 側で未認証に落ちる）。
+      // 注: 並列リクエストで同時実行されると同じ refresh_token を独立に使う。現在の realm 設定
+      // （config/keycloak/realm-export.json: revokeRefreshToken=false）では再利用可能なため安全。
+      // リフレッシュトークンローテーションを有効化する場合は先勝ち以外が invalid_grant で
+      // 誤サインアウトしうるので、更新の直列化・ミューテックスが必要になる。
+      return refreshAccessToken(token, {
+        tokenEndpoint,
+        clientId: process.env.AUTH_KEYCLOAK_ID ?? '',
+        clientSecret: process.env.AUTH_KEYCLOAK_SECRET ?? '',
+      })
     },
-    // proxy が Kong へ渡せるよう accessToken を、UI 表示用に user.id(sub) を公開する
+    // proxy が Kong へ渡せるよう accessToken を、UI 表示用に user.id(sub) を公開する。
+    // リフレッシュ失敗時は error を伝播し、クライアント側で未認証扱い＆サインアウトさせる。
     async session({ session, token }) {
-      session.accessToken = token.accessToken as string | undefined
+      // リフレッシュ不能時は失効済みアクセストークンを proxy に渡さない（Kong へ送っても
+      // 401 になるだけなので、error のみ伝播して SessionGuard に signOut を委ねる）。
+      session.accessToken = token.error ? undefined : (token.accessToken as string | undefined)
+      session.error = token.error as string | undefined
       if (session.user) session.user.id = token.sub ?? ''
       return session
     },

--- a/services/frontend/src/components/Providers.tsx
+++ b/services/frontend/src/components/Providers.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import { SessionProvider } from 'next-auth/react'
+import SessionGuard from '@/components/SessionGuard'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+  return (
+    <SessionProvider>
+      <SessionGuard />
+      {children}
+    </SessionProvider>
+  )
 }

--- a/services/frontend/src/components/SessionGuard.tsx
+++ b/services/frontend/src/components/SessionGuard.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession, signOut } from 'next-auth/react'
+
+/**
+ * アクセストークンのリフレッシュに失敗（SSO セッション切れ等）したセッションを検知して、
+ * 残存する NextAuth の Cookie を破棄する。これがないと「ログインしていないのにユーザー名が
+ * 表示される」不整合な Cookie が最大 30 日残り続ける。redirect はしない（現在ページに留まり、
+ * UI は useAuthUser 側で未認証表示に切り替わる）。
+ */
+export default function SessionGuard() {
+  const { data: session } = useSession()
+
+  useEffect(() => {
+    if (session?.error === 'RefreshTokenError') {
+      signOut({ redirect: false })
+    }
+  }, [session?.error])
+
+  return null
+}

--- a/services/frontend/src/lib/__tests__/auth.test.ts
+++ b/services/frontend/src/lib/__tests__/auth.test.ts
@@ -41,6 +41,23 @@ describe('useAuthUser', () => {
     expect(user).toBeNull()
   })
 
+  it('リフレッシュ失敗(error)のセッションは未認証扱いで user を返さない', () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        user: { id: 'kc-sub-123', email: 'user@example.com', name: 'ゴリラ太郎' },
+        error: 'RefreshTokenError',
+        expires: '2999-01-01',
+      },
+      // NextAuth の Cookie 自体は生きているので status は authenticated のまま来るが、
+      // トークンが失効しているので未認証として扱う。
+      status: 'authenticated',
+    } as never)
+
+    const { user, status } = useAuthUser()
+    expect(status).toBe('unauthenticated')
+    expect(user).toBeNull()
+  })
+
   it('email / name が欠けても空文字で補完する', () => {
     mockedUseSession.mockReturnValue({
       data: { user: { id: 'kc-sub-789' }, expires: '2999-01-01' },

--- a/services/frontend/src/lib/__tests__/token-refresh.test.ts
+++ b/services/frontend/src/lib/__tests__/token-refresh.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isAccessTokenValid, refreshAccessToken } from '../token-refresh'
+
+const REFRESH_OPTS = {
+  tokenEndpoint: 'http://keycloak:8081/realms/jungle-store/protocol/openid-connect/token',
+  clientId: 'jungle-store-frontend',
+  clientSecret: 'secret',
+}
+
+describe('isAccessTokenValid', () => {
+  const now = 1_000_000_000_000 // 固定の現在時刻(ms)
+
+  it('有効期限まで十分に猶予があれば true', () => {
+    // expiresAt はエポック秒。now の 5 分後。
+    const token = { expiresAt: now / 1000 + 300 }
+    expect(isAccessTokenValid(token, now)).toBe(true)
+  })
+
+  it('既に失効していれば false', () => {
+    const token = { expiresAt: now / 1000 - 1 }
+    expect(isAccessTokenValid(token, now)).toBe(false)
+  })
+
+  it('マージン(30秒)以内に切れる場合は事前更新のため false', () => {
+    const token = { expiresAt: now / 1000 + 10 }
+    expect(isAccessTokenValid(token, now)).toBe(false)
+  })
+
+  it('expiresAt が無ければ false（判定不能なので更新を促す）', () => {
+    expect(isAccessTokenValid({}, now)).toBe(false)
+  })
+})
+
+describe('refreshAccessToken', () => {
+  const now = 1_000_000_000_000
+
+  it('refresh_token でアクセストークンを更新し expiresAt / error を更新する', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expires_in: 300,
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const result = await refreshAccessToken(
+      { accessToken: 'old', refreshToken: 'old-refresh', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(result.accessToken).toBe('new-access')
+    expect(result.refreshToken).toBe('new-refresh')
+    expect(result.expiresAt).toBe(now / 1000 + 300)
+    expect(result.error).toBeUndefined()
+
+    // Keycloak の token エンドポイントへ grant_type=refresh_token で POST している
+    const [url, options] = fetchImpl.mock.calls[0]
+    expect(url).toBe(REFRESH_OPTS.tokenEndpoint)
+    expect(options.method).toBe('POST')
+    const body = options.body as URLSearchParams
+    expect(body.get('grant_type')).toBe('refresh_token')
+    expect(body.get('refresh_token')).toBe('old-refresh')
+    expect(body.get('client_id')).toBe(REFRESH_OPTS.clientId)
+    expect(body.get('client_secret')).toBe(REFRESH_OPTS.clientSecret)
+  })
+
+  it('レスポンスに refresh_token が無ければ既存の refresh_token を維持する', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'new-access', expires_in: 300 }), {
+        status: 200,
+      }),
+    )
+
+    const result = await refreshAccessToken(
+      { refreshToken: 'keep-me', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(result.refreshToken).toBe('keep-me')
+    expect(result.accessToken).toBe('new-access')
+  })
+
+  it('refresh_token が無ければ更新せず error を立てる', async () => {
+    const fetchImpl = vi.fn()
+
+    const result = await refreshAccessToken(
+      { accessToken: 'old', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(result.error).toBe('RefreshTokenError')
+  })
+
+  it('Keycloak が失敗（refresh_token 失効など）を返したら error を立てる', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 }))
+
+    const result = await refreshAccessToken(
+      { accessToken: 'old', refreshToken: 'expired', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(result.error).toBe('RefreshTokenError')
+    // 失効したアクセストークンはそのまま（session 側で未認証扱いにする）
+    expect(result.accessToken).toBe('old')
+  })
+
+  it('expires_in が欠落した異常応答は error 扱い（即時失効ループを防ぐ）', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ access_token: 'new-access' }), { status: 200 }),
+      )
+
+    const result = await refreshAccessToken(
+      { accessToken: 'old', refreshToken: 'r', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(result.error).toBe('RefreshTokenError')
+  })
+
+  it('fetch が例外を投げても error を立てて握りつぶす', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'))
+
+    const result = await refreshAccessToken(
+      { refreshToken: 'r', expiresAt: now / 1000 - 1 },
+      { ...REFRESH_OPTS, fetchImpl, now },
+    )
+
+    expect(result.error).toBe('RefreshTokenError')
+  })
+})

--- a/services/frontend/src/lib/auth.ts
+++ b/services/frontend/src/lib/auth.ts
@@ -17,12 +17,17 @@ export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated'
  */
 export function useAuthUser(): { user: AuthUser | null; status: AuthStatus } {
   const { data: session, status } = useSession()
-  const user = session?.user
-    ? {
-        id: session.user.id,
-        email: session.user.email ?? '',
-        name: session.user.name ?? '',
-      }
-    : null
-  return { user, status }
+  // アクセストークンのリフレッシュに失敗したセッションは「見た目はログイン中だが実体は
+  // 未認証」の状態。UI 上は未認証として扱い、ユーザー名を表示しない。
+  const errored = session?.error === 'RefreshTokenError'
+  const user =
+    session?.user && !errored
+      ? {
+          id: session.user.id,
+          email: session.user.email ?? '',
+          name: session.user.name ?? '',
+        }
+      : null
+  const effectiveStatus: AuthStatus = errored ? 'unauthenticated' : status
+  return { user, status: effectiveStatus }
 }

--- a/services/frontend/src/lib/token-refresh.ts
+++ b/services/frontend/src/lib/token-refresh.ts
@@ -1,0 +1,96 @@
+/**
+ * Keycloak アクセストークンのライフサイクル管理。
+ *
+ * NextAuth のセッション Cookie（既定 30 日）は Keycloak のアクセストークン（既定 5 分）より
+ * 遥かに長寿命なため、何もしないとトークン失効後もセッションだけが生き残り「ログインしている
+ * ように見えて実際は未認証」という不整合が起きる。ここで expires_at を監視し、失効時は
+ * refresh_token で更新、更新不能なら error を立てて session 側で未認証扱いに落とす。
+ *
+ * auth.ts の jwt コールバックから利用する純粋関数として切り出し、NextAuth 非依存で単体テスト
+ * できるようにしている。
+ */
+
+// 失効ギリギリのトークンを掴まないための事前更新マージン（秒）
+const EXPIRY_MARGIN_SEC = 30
+
+export interface RefreshableToken {
+  accessToken?: string
+  refreshToken?: string
+  /** アクセストークンの有効期限（エポック秒） */
+  expiresAt?: number
+  /** リフレッシュ不能時に設定。session 側でこれを見て未認証扱いにする */
+  error?: string
+  [key: string]: unknown
+}
+
+export interface RefreshOptions {
+  tokenEndpoint: string
+  clientId: string
+  clientSecret: string
+  fetchImpl?: typeof fetch
+  /** テスト用の現在時刻(ms)。既定は Date.now() */
+  now?: number
+}
+
+/**
+ * アクセストークンがまだ有効か（マージン込み）を判定する。
+ * expiresAt が無い場合は判定不能なので false（＝更新を促す）。
+ */
+export function isAccessTokenValid(token: RefreshableToken, now: number = Date.now()): boolean {
+  if (!token.expiresAt) return false
+  return now < token.expiresAt * 1000 - EXPIRY_MARGIN_SEC * 1000
+}
+
+/**
+ * refresh_token を使って Keycloak からアクセストークンを再取得する。
+ * 更新できない（refresh_token なし / 失効 / 通信エラー）場合は error を立てて返す。
+ * 例外は投げず、常に更新後トークンを解決する（jwt コールバックを壊さないため）。
+ */
+export async function refreshAccessToken(
+  token: RefreshableToken,
+  opts: RefreshOptions,
+): Promise<RefreshableToken> {
+  const { tokenEndpoint, clientId, clientSecret, fetchImpl = fetch, now = Date.now() } = opts
+
+  if (!token.refreshToken) {
+    return { ...token, error: 'RefreshTokenError' }
+  }
+
+  try {
+    const res = await fetchImpl(tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: token.refreshToken,
+      }),
+    })
+
+    const refreshed = (await res.json()) as {
+      access_token?: string
+      refresh_token?: string
+      expires_in?: number
+      error?: string
+    }
+
+    // expires_in が無い/非正なら expiresAt が現在時刻となり毎リクエストで再更新が走る
+    // （Keycloak を叩き続けるループ）ため、異常応答として扱い error に落とす。
+    if (!res.ok || !refreshed.access_token || !refreshed.expires_in || refreshed.expires_in <= 0) {
+      throw new Error(refreshed.error ?? `refresh failed: ${res.status}`)
+    }
+
+    return {
+      ...token,
+      accessToken: refreshed.access_token,
+      // Keycloak はローテーションで新しい refresh_token を返すことがある。無ければ現行を維持。
+      refreshToken: refreshed.refresh_token ?? token.refreshToken,
+      expiresAt: Math.floor(now / 1000) + refreshed.expires_in,
+      error: undefined,
+    }
+  } catch {
+    // refresh_token の失効（SSO セッション切れ等）を含む。session 側で未認証に落とす。
+    return { ...token, error: 'RefreshTokenError' }
+  }
+}

--- a/services/frontend/src/types/next-auth.d.ts
+++ b/services/frontend/src/types/next-auth.d.ts
@@ -3,6 +3,8 @@ import type { DefaultSession } from 'next-auth'
 declare module 'next-auth' {
   interface Session {
     accessToken?: string
+    /** アクセストークンのリフレッシュに失敗した場合に 'RefreshTokenError' が入る */
+    error?: string
     user: {
       id: string
     } & DefaultSession['user']
@@ -12,5 +14,10 @@ declare module 'next-auth' {
 declare module 'next-auth/jwt' {
   interface JWT {
     accessToken?: string
+    refreshToken?: string
+    /** アクセストークンの有効期限（エポック秒） */
+    expiresAt?: number
+    /** リフレッシュ不能時に 'RefreshTokenError' が入る */
+    error?: string
   }
 }


### PR DESCRIPTION
## 概要

「アプリを起動するとログインしていないのにユーザー名が表示される」不具合を修正します。

## 根本原因

NextAuth のセッション Cookie（既定 **30 日**）が Keycloak のアクセストークン（`config/keycloak/realm-export.json` の `accessTokenLifespan: 300` = **5 分**）より遥かに長寿命で、失効判定もリフレッシュも存在しませんでした。UI（`Nav` → `useAuthUser` → `useSession`）は NextAuth セッションの有無だけでログイン状態を判定していたため、**トークン失効後・翌日の再起動後でも Cookie が残る限りユーザー名が表示され続ける**（実体は未認証 → API は 401）という不整合が発生していました。

| 寿命 | 値 |
|---|---|
| Keycloak access token | 5 分 (`accessTokenLifespan: 300`) |
| Keycloak SSO セッション最大 | 10 時間 (`ssoSessionMaxLifespan: 36000`) |
| NextAuth セッション Cookie | 30 日（既定のまま） |

## 修正内容

- **`lib/token-refresh.ts`（新規）**: 失効判定 `isAccessTokenValid`（30 秒マージン）+ refresh_token による更新 `refreshAccessToken`。NextAuth 非依存の純粋関数として単体テスト可能に切り出し
- **`auth.ts`**: `jwt` コールバックで `expiresAt`/`refreshToken` を保持し、失効時にリフレッシュ。`session` コールバックで `error` を伝播し、**リフレッシュ不能時は失効トークンを proxy に渡さない**
- **`lib/auth.ts`**: `useAuthUser` が `RefreshTokenError` を未認証扱い（ユーザー名を隠す）
- **`SessionGuard.tsx`（新規）+ `Providers.tsx`**: `error` 検知で自動 `signOut` し、失効 Cookie を破棄
- **`login/page.tsx`**: `useAuthUser` に統一し、失効ユーザーが再ログインできない問題を解消
- **`types/next-auth.d.ts`**: 型追加

## 挙動（修正後）

- 操作中はアクセストークンが失効しても refresh_token で自動更新され、ログインが維持される
- SSO セッション（最大 10 時間 / アイドル 30 分）が切れて refresh_token も失効すると、`error` が立ち UI が未認証表示に切り替わり、失効 Cookie が破棄される

## テスト

- `token-refresh.test.ts`（新規 10 件）: 失効判定・リフレッシュ成功/失敗・異常応答
- `auth.test.ts`（+1 件）: error セッションの未認証扱い
- 全 28 件パス / `tsc --noEmit` クリーン / Prettier クリーン
- code-reviewer による独立レビュー実施済み（Warning 1 = 失効トークン送出の修正、Nit 2 = 並行リフレッシュの realm 依存をコメント明示、Nit 3/4 = 修正 反映済み）

> 注: 5 分のトークン失効を伴う実挙動はライブスタックでは未確認（時間経過が必要なため）。ロジックは単体テストで網羅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)