### PR TITLE
fix: Event Gateway 1.2.0 の環境変数・設定スキーマ変更に追従

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -199,15 +199,15 @@ services:
     image: kong/kong-event-gateway:1.2.0
     environment:
       # see: https://developer.konghq.com/event-gateway/configuration/
-      KONNECT_REGION: us
-      KONNECT_DOMAIN: konghq.com
-      KONNECT_GATEWAY_CLUSTER_ID: ${EVENT_GATEWAY_CP_ID:-}
-      KONNECT_CLIENT_CERT_PATH: /etc/kong/cluster-certs/cluster.crt
-      KONNECT_CLIENT_KEY_PATH: /etc/kong/cluster-certs/cluster.key
+      KONG_KONNECT_REGION: us
+      KONG_KONNECT_DOMAIN: konghq.com
+      KONG_KONNECT_GATEWAY_CLUSTER_ID: ${EVENT_GATEWAY_CP_ID:-}
+      KONG_KONNECT_CLIENT_CERT_PATH: /etc/kong/cluster-certs/cluster.crt
+      KONG_KONNECT_CLIENT_KEY_PATH: /etc/kong/cluster-certs/cluster.key
       KEG__OBSERVABILITY__LOG_FLAGS: info
       KEG__OBSERVABILITY__LOG_FORMAT: json
       KEG__OBSERVABILITY__METRICS_ROLLUP_ALLOW_MAP: 'api_kind=produce,fetch'
-      KEG__OBSERVABILITY__OTLP__TRACING__ENABLED: true
+      KEG__OBSERVABILITY__OTEL__TRACES__ENDPOINT: http://otel-lgtm:4318/v1/traces
       OTEL_SERVICE_NAME: event-gateway
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-lgtm:4318
     ports:


### PR DESCRIPTION
## 概要

`kong/kong-event-gateway:1.2.0`（#42 でピン留め）は旧環境変数・設定スキーマを **警告ではなく起動拒否（fatal）** として扱うため、`event-gateway` コンテナが起動時に Exit 1 で落ちていた。その結果 docker ネットワーク上でホスト名 `event-gateway` が解決できず（`getaddrinfo ENOTFOUND event-gateway`）、order-service / shipping-service の Kafka 経路が全断し、**order → shipping の連携が機能しない**状態だった。

## 根本原因

起動ログに 2 段のエラー:

1. `KONNECT_* -> rename to KONG_KONNECT_*`（deprecated 環境変数が fatal 化）
2. `unknown field 'otlp', expected one of ... 'otel'`（observability 設定スキーマ変更）

## 修正

`compose.yaml` の event-gateway 定義のみ変更:

- `KONNECT_*` → `KONG_KONNECT_*`（5 変数）
- `KEG__OBSERVABILITY__OTLP__TRACING__ENABLED: true` → `KEG__OBSERVABILITY__OTEL__TRACES__ENDPOINT: http://otel-lgtm:4318/v1/traces`（新スキーマではエンドポイント設定でトレース有効化）

## 動作確認（E2E）

- `event-gateway` が `Up (healthy)` になり、仮想クラスタ・リスナー（19091-19094）・kafka:9092 への接続を確立
- order/shipping が Kafka に再接続し、それぞれ `order.status-updated` / `order.created` を購読
- 管理 API キー経路で注文作成 → `order.created` 発行 → shipping が配送作成 → `order.status-updated`(CONFIRMED→SHIPPED) 往復を確認
- 最終: 注文 status = **SHIPPED**、配送レコード生成（追跡番号付き）

🤖 Generated with [Claude Code](https://claude.com/claude-code)