### PR TITLE
fix: order/shipping を Event Gateway が healthy になるまで待機させる

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -217,6 +217,14 @@ services:
       - '19094:19094'
     volumes:
       - ./certs/event-gateway:/etc/kong/cluster-certs
+    healthcheck:
+      # distroless イメージ（シェル/curl 無し）のため keg バイナリ内蔵の healthcheck を使う。
+      # Konnect から設定を取得し Kafka リスナーが受付可能になると OK を返す。
+      test: ['CMD', '/keg', 'healthcheck']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     depends_on:
       kafka:
         condition: service_healthy
@@ -368,7 +376,7 @@ services:
       mysql:
         condition: service_healthy
       event-gateway:
-        condition: service_started
+        condition: service_healthy
     develop:
       watch:
         - action: sync
@@ -407,7 +415,7 @@ services:
       mysql:
         condition: service_healthy
       event-gateway:
-        condition: service_started
+        condition: service_healthy
     develop:
       watch:
         - action: sync


### PR DESCRIPTION
## 概要

order → shipping の非同期フローが止まる問題を修正します。

## 原因

`mise run setup` の再同期で Event Gateway が order/shipping より遅れて起動した際、以下の連鎖で producer が切断状態のまま固定されていました。

1. order/shipping は起動直後に Kafka（Event Gateway）へ接続を試みるが、Event Gateway 未起動で `ECONNREFUSED`
2. 数秒（5回）リトライ後に諦め `Failed to connect Kafka, starting without it` で degraded 起動、**以降再接続しない**
3. Event Gateway が後から起動しても producer は切断のまま → 注文時に `The producer is disconnected` で `order.created` 発行失敗 → shipping に届かない

`depends_on: event-gateway` は既にあったが条件が `service_started`（コンテナ起動のみ）で、Kafka リスナーが受付可能になる前に order/shipping が立ち上がっていた。

## 変更内容

- **event-gateway に healthcheck を追加**: distroless イメージ（シェル/curl 無し）のため `keg` バイナリ内蔵の `/keg healthcheck` を使用。Konnect から設定を取得し Kafka リスナーが受付可能になると OK を返す。
- **order/shipping の `depends_on: event-gateway` を `service_started` → `service_healthy` に変更**: Kafka を受付可能になるまで起動を待たせる。

## 検証

- `docker compose config -q` → OK
- event-gateway 作り直し後 `State.Health.Status=healthy` を確認
- order/shipping 再起動後 `Kafka producer connected` を確認

## 既知の限界

`depends_on` は `up` 時の順序を保証するが、単一サービスだけ後から作り直すと依存元は自動再起動されない。その場合は `docker compose restart order-service shipping-service` が必要（producer の遅延再接続はスコープ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)