### PR TITLE
feat: Claude Code ハーネスを拡充（構文検証フック・契約マップ/PR スキル・CI）

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -14,6 +14,7 @@ model: opus
 - Zod スキーマとハンドラー実装の不整合（レスポンスがスキーマと合わない、Date の toISOString 漏れ）
 - Prisma クエリの誤り（where 条件、トランザクション境界、N+1）
 - Kafka producer/consumer のエラーハンドリング（order/shipping-service）
+- サービス境界をまたぐ識別子の変更（Kafka トピック名、イベントペイロードのフィールド、Kong ルートパス、`X-User-*` ヘッダ、他サービスが fetch する API の形状）で片側だけ更新されていないか — 連動箇所の一覧は `.claude/skills/cross-service-contracts/SKILL.md` を参照。この種の破壊は型エラーにならず実行時に静かに壊れるため Critical 扱い
 - テストがモックの都合に合わせて実装の誤りを固定化していないか
 
 ### プロジェクト規約（CLAUDE.md 準拠）

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -9,7 +9,7 @@ model: sonnet
 
 ## 必須ワークフロー
 
-1. CLAUDE.md と、タスクに関連するスキル（`.claude/skills/add-endpoint`、`new-service` 等）を読む。該当スキルがあれば必ずその手順に従う。
+1. CLAUDE.md と、タスクに関連するスキル（`.claude/skills/add-endpoint`、`new-service` 等）を読む。該当スキルがあれば必ずその手順に従う。変更がサービス境界をまたぐ場合（Kafka トピック/ペイロード、Kong ルートパス、`X-User-*` ヘッダ、他サービスから参照される Prisma フィールド）は `cross-service-contracts` スキルで連動箇所を洗い出してから着手する。
 2. 変更対象サービスの既存コード（routes.ts、**tests**/）を読み、パターンを踏襲する。
 3. **テストを先に書き、失敗を確認してから実装する**（vitest、Prisma は vi.mock）。
 4. 実装後に必ず実行し、出力を確認する:

--- a/.claude/hooks/post-edit.sh
+++ b/.claude/hooks/post-edit.sh
@@ -7,13 +7,50 @@ file_path=$(get_tool_input_field "$input" "file_path")
 [ ! -f "$file_path" ] && exit 0
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+# prettier / tsc は各使用箇所で [ -x ] ガード済み（node_modules 不在でも後続の構文検証は動かす）
 BIN="$PWD/node_modules/.bin"
-[ -d "$BIN" ] || exit 0
 
 # lint-staged と同じ対象拡張子（package.json の lint-staged glob が正）を Prettier で整形
 case "$file_path" in
   *.js | *.jsx | *.ts | *.tsx | *.json | *.css | *.md | *.yaml | *.yml)
     [ -x "$BIN/prettier" ] && "$BIN/prettier" --write "$file_path" >/dev/null 2>&1
+    ;;
+esac
+
+# 設定ファイルの構文バリデーション。Prettier はパース不能なファイルを黙って素通しする
+# （2>/dev/null で失敗を握りつぶしている）ため、ここで構文エラーを検出して即フィードバック
+# する。検証ツールが無い環境ではフェイルオープン。
+case "$file_path" in
+  *.yaml | *.yml)
+    if command -v yq >/dev/null 2>&1; then
+      if ! errors=$(yq e 'true' "$file_path" 2>&1 >/dev/null); then
+        echo "YAML syntax error in $file_path:" >&2
+        printf '%s\n' "$errors" | head -10 >&2
+        exit 2
+      fi
+    fi
+    # compose ファイルはスキーマまで検証する（docker compose config はクライアント側で完結）
+    case "$(basename "$file_path")" in
+      compose.yaml | compose.yml | docker-compose.yaml | docker-compose.yml)
+        if command -v docker >/dev/null 2>&1; then
+          if ! errors=$(docker compose -f "$file_path" config -q 2>&1); then
+            echo "compose validation error in $file_path:" >&2
+            printf '%s\n' "$errors" | head -10 >&2
+            exit 2
+          fi
+        fi
+        ;;
+    esac
+    ;;
+  */tsconfig*.json | */.vscode/*.json) ;; # JSONC（コメント付き JSON）を許容するファイルは対象外
+  *.json)
+    if command -v node >/dev/null 2>&1; then
+      if ! errors=$(node -e 'JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"))' "$file_path" 2>&1); then
+        echo "JSON syntax error in $file_path:" >&2
+        printf '%s\n' "$errors" | head -5 >&2
+        exit 2
+      fi
+    fi
     ;;
 esac
 

--- a/.claude/hooks/run-tests.sh
+++ b/.claude/hooks/run-tests.sh
@@ -72,6 +72,33 @@ expect 2 protect-files.sh "$(payload file_path /repo/package-lock.json)" "packag
 expect 0 protect-files.sh "$(payload file_path /repo/.env.example)" ".env.example allowed"
 expect 0 protect-files.sh "$(payload file_path /repo/services/order-service/src/routes.ts)" "normal file allowed"
 
+# ---- post-edit.sh（設定ファイルの構文バリデーション）----
+TEST_PROJECT_DIR="$PWD"
+printf 'key: value\n' >"$TMP/good.yaml"
+printf 'key: [unclosed\n' >"$TMP/bad.yaml"
+printf '{ "a": 1 }\n' >"$TMP/good.json"
+printf '{ "a": 1\n' >"$TMP/bad.json" # trailing comma 等は prettier が自動修復するため、修復不能な構文エラーを使う
+printf '{ /* jsonc */ "a": 1 }\n' >"$TMP/tsconfig.json"
+expect 0 post-edit.sh "$(payload file_path "$TMP/good.yaml")" "valid yaml passes"
+expect 2 post-edit.sh "$(payload file_path "$TMP/bad.yaml")" "invalid yaml blocks"
+expect 0 post-edit.sh "$(payload file_path "$TMP/good.json")" "valid json passes"
+expect 2 post-edit.sh "$(payload file_path "$TMP/bad.json")" "invalid json blocks"
+expect 0 post-edit.sh "$(payload file_path "$TMP/tsconfig.json")" "tsconfig (JSONC) skips json check"
+# 構文検証は node_modules（prettier/tsc）不在の環境でも動くこと
+TEST_PROJECT_DIR="$TMP"
+expect 2 post-edit.sh "$(payload file_path "$TMP/bad.yaml")" "validation runs without node_modules"
+TEST_PROJECT_DIR="$PWD"
+
+if command -v docker >/dev/null 2>&1; then
+  mkdir -p "$TMP/good-compose" "$TMP/bad-compose"
+  printf 'services:\n  web:\n    image: nginx\n' >"$TMP/good-compose/compose.yaml"
+  printf 'services:\n  web:\n    imagee: nginx\n' >"$TMP/bad-compose/compose.yaml"
+  expect 0 post-edit.sh "$(payload file_path "$TMP/good-compose/compose.yaml")" "valid compose passes"
+  expect 2 post-edit.sh "$(payload file_path "$TMP/bad-compose/compose.yaml")" "invalid compose schema blocks"
+else
+  echo "SKIP: docker が無いため compose バリデーションのテストをスキップ" >&2
+fi
+
 # ---- post-edit.sh（型チェックの発火条件のみ。整形は実ファイルが必要なため対象外）----
 mkdir -p "$TMP/services/bad-service/src/__tests__"
 printf '{"compilerOptions":{"strict":true,"noEmit":true},"include":["src"],"exclude":["src/__tests__"]}' >"$TMP/services/bad-service/tsconfig.json"

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: create-pr
+description: Use when implementation on a branch is complete and ready to become a pull request — when the user says「PRを作って」「プルリクを出して」, or when finishing any implementation task (CLAUDE.md requires all merges to go through a PR).
+---
+
+# PR 作成フロー
+
+CLAUDE.md 規約「実装 → レビュー → PR」の実行手順。main への直接コミットはフックでブロックされる。
+
+## 手順
+
+1. **ブランチ確認**: `git branch --show-current` がセマンティックなブランチ名（`feature/xxx` / `bugfix/xxx` / `chore/xxx`）であること。main 上なら先にブランチを作成する。
+
+2. **検証を全て通す**（変更内容に応じて選択。1 つでも失敗したら修正してからやり直す）:
+
+   ```bash
+   npm run format:check
+   npx tsc --noEmit -p services/<変更したサービス>   # packages/shared を触ったら全サービス + frontend を対象にする
+   npm run test -w services/<変更したサービス>       # 変更が複数サービスに及ぶ場合はルートで npm run test
+   docker compose config -q                          # compose.yaml を変更した場合
+   bash .claude/hooks/run-tests.sh                   # .claude/hooks/ を変更した場合
+   ```
+
+3. **コードレビュー**: `code-reviewer` サブエージェントに working diff のレビューを依頼する。Critical / Warning の指摘は妥当性を検証した上で修正し、手順 2 を再実行する（指摘の鵜呑みも無視もしない）。
+
+4. **コミット**: セマンティックコミット規約（`feat:` / `fix:` / `chore:` / `docs:` 等）。タスクと無関係な変更を混ぜない。
+
+5. **PR 作成**: `git push -u origin <branch>` → `gh pr create`。PR body に含めること:
+   - 概要と変更点
+   - **テスト結果**: 実際に実行したコマンドと結果の要約（実行していない項目は「未検証」と明記する）
+   - **Konnect 反映の要否**: `config/kong/kong.yaml` または `kongctl/` を変更した場合は「マージ後に `/sync-konnect`（ユーザー実行）が必要」と明記
+
+6. PR URL を報告する。マージはユーザーの判断（自動マージしない）。
+
+## よくある間違い
+
+- 検証をスキップして PR 作成 → PR body の「テスト結果」欄は実行の証拠を書く欄。書けない = 手順 2 に戻る
+- kong.yaml / kongctl の変更がマージだけで反映されると誤認 → 反映は別途 `/sync-konnect` が必要
+- 新しい環境変数を `.env.example` に追記し忘れる → `.env` は編集禁止のため、`.env.example` 更新 + ユーザーへの反映依頼が唯一の経路
+- レビュー指摘の修正後に再検証を忘れる → 修正のたびに手順 2 に戻る

--- a/.claude/skills/cross-service-contracts/SKILL.md
+++ b/.claude/skills/cross-service-contracts/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: cross-service-contracts
+description: Use when planning or reviewing a change that crosses service boundaries — renaming/moving Kafka topics or event payload fields, Kong route paths, X-User-* headers, Prisma schema fields, compose.yaml anchors, consumer groups — or when asking「他にどこを直す必要がある?」during refactoring.
+---
+
+# サービス間コントラクト（暗黙の契約）マップ
+
+## 原則
+
+このリポジトリのサービス間契約は**型で繋がっていない**。producer/consumer のペイロード、Kong ルートとフロントエンドのパス、ヘッダ名、他サービスの API レスポンス形状は、すべて各所に**文字列リテラル/インライン型として重複定義**されている。片側だけ変更してもコンパイルエラーにならず、実行時に静かに壊れる。変更前にこの表で連動箇所を洗い出し、変更後は `grep -rn '<旧識別子>' --exclude-dir=node_modules .` がゼロ件になることを確認する。
+
+## 罠: packages/shared は見た目ほど中央ではない
+
+`packages/shared` の `types/`（Product/Order/イベント型）と `kafka/`（`KAFKA_TOPICS` 等の定数）は**どのサービスからも import されていない死蔵コード**。実際に使われているのは `createLogger` / `createErrorHandler` / `createNotFoundHandler` のみ（これらの変更は全 6 サービスに波及する）。shared の型・定数だけ直して「リネーム完了」と判断しないこと。
+
+## 変更 → 連動箇所チェックリスト
+
+### Kafka トピック名 / consumer group 名
+
+- 各サービスの `src/kafka.ts` `src/consumer.ts` のリテラル（order-service, shipping-service）
+- `kongctl/event-gateways.yaml` の Virtual Cluster ACL `match:` ルール — **default-deny のため未更新だと "Topic authorization failed" で非同期フローだけが静かに死ぬ**（HTTP の注文作成は成功し続けるので気づきにくい）。反映は `/sync-konnect`
+- `compose.yaml` の `kafka-init`（トピック作成コマンド）。既存 Kafka volume には旧トピックが残るため `docker compose down -v` か手動削除が必要
+- 各サービスのテスト（`producer.send` のトピック名アサーション）
+- ドキュメント: `guides/event-gateway.md`, `guides/demos/*`, `kongctl/portals/docs/*_ja.md`（ポータル公開物。反映に kongctl sync が必要）
+
+### Kafka イベントペイロードのフィールド
+
+- producer 側: order-service `src/routes.ts`（order.created）、shipping-service `src/consumer.ts`（order.status-updated）
+- consumer 側: shipping-service `src/consumer.ts`、order-service `src/consumer.ts` — 手書きの分割代入 + if チェックのみで、スキーマ検証は存在しない
+- 両側のテスト
+
+### Kong ルートパス / strip_path
+
+- `config/kong/kong.yaml`: ブラウザ経路は `strip_path: false`（パス = バックエンドのベースパス）、`/admin/api/*` は `strip_path: true` + `service.path` のリライト算術
+- フロントエンドのハードコードパス: `services/frontend/src/` 配下の `apiFetch('/api/...')` 呼び出し（page.tsx, cart/page.tsx, orders/, Nav.tsx, AskAIDialog.tsx）
+- バックエンドのルーターマウントパス（各 `routes.ts`）
+- 反映は `/sync-konnect`
+
+### X-User-Id / X-User-Email / X-User-Name ヘッダ
+
+- `config/kong/kong.yaml`: openid-connect の `upstream_headers_names`、admin 経路の `request-transformer`、CORS の許可ヘッダ
+- 読み取り側: cart/order/shipping の各 `routes.ts`（X-User-Id で 401/400 判定）、**user-service は 3 つ全部読んでユーザーを upsert する**（プロビジョニングが壊れる）
+
+### Prisma スキーマ（他サービスから参照されるフィールド）
+
+- catalog `Product.stock` / `.name` / `.price` — order-service が注文作成時に `/api/products/:id` を fetch して在庫検証に使う。フロントも `productId` から商品名を解決する
+- cart のアイテム形状（`items[].productId/quantity/price`）— order-service が注文作成時に `/api/carts` を fetch して消費する
+- `price` は全スキーマで `Int`（整数円）。`status` は自由文字列で、値の集合（PENDING/CONFIRMED/SHIPPED/DELIVERED）はフロントのラベル定義・shipping の consumer と暗黙に共有
+- productId / userId / orderId は DB 間 FK なしの素の文字列参照（userId = Keycloak の `sub`）
+
+### routes.ts / Zod スキーマ（公開 API の形状）
+
+- ライブの `/openapi.json` は自動追従するが、**ポータル公開スペック `kongctl/portals/apis/<svc>/openapi.yaml` は手動コミットで自動生成されない** — ルート変更時は手動同期しないとポータルだけ古いまま残る
+- フロントエンドはレスポンス型を各 page.tsx にインライン再定義している（`{ products, total }`、エラーは `{ error: string }`）
+
+### compose.yaml
+
+- `x-otel-env` アンカーは Prisma 系 5 サービスのみ継承。**agent-service と frontend は OTel 環境変数を手書きしているため、アンカー変更が波及しない**
+- order/shipping の Kafka ブローカーはコードのデフォルト（localhost）ではなく `KAFKA_BROKER` 環境変数（event-gateway のリスナーポート、`kongctl/event-gateways.yaml` と対応）に依存
+
+## 検証
+
+連動箇所を直したら: 旧識別子の grep ゼロ確認 → 影響サービスの `tsc --noEmit` + テスト → `docker compose config -q`（compose 変更時）→ スタック起動中なら `/verify-stack`（Kafka フローは `--with-order`）。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
           name: coverage-${{ matrix.service }}
           path: services/${{ matrix.service }}/coverage/
 
+  hooks:
+    name: Claude Code Hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+      # 型チェックテストが node_modules/.bin/tsc・prettier を参照するため npm ci が必要
+      - run: npm ci
+      - run: bash .claude/hooks/run-tests.sh
+
   pin-check:
     name: Pinned Actions
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ services/<名前>/src/
 
 - `add-endpoint` — バックエンドサービスへの API エンドポイント追加手順（TDD + Zod/createRoute パターン）
 - `new-service` — 新規マイクロサービス作成のチェックリスト（compose.yaml / kong.yaml / DB 初期化まで）
+- `cross-service-contracts` — サービス間の暗黙契約マップ。サービス境界をまたぐ変更・リファクタリングの前に連動箇所（Kafka トピック ↔ Event Gateway ACL、Kong ルート ↔ フロントのパス、`X-User-*` ヘッダ等）を洗い出すためのリファレンス
+- `create-pr` — 実装完了からの PR 作成フロー（検証 → code-reviewer レビュー → セマンティックコミット → gh pr create）
 - `verify-stack` — スタック全体のスモークテスト（ヘルスチェック、Kong プラグイン、Kafka フロー）
 - `sync-konnect` — Konnect への設定反映（ユーザー実行専用。diff → 承認 → sync）
 - `kongctl-declarative` / `kongctl-extension-builder` — kongctl CLI が配布する公式スキル（実体は `.claude/skills/` 配下、`.agents/skills/` からシンボリックリンク。kongctl での再インストール時は配置先に注意）
@@ -187,10 +189,10 @@ services/<名前>/src/
 
 ### フック（.claude/hooks/、settings.json で有効化）
 
-- 編集時に Prettier 自動整形 + サービス単位の型チェック（型エラーは即フィードバックされる）
+- 編集時に Prettier 自動整形 + サービス単位の型チェック（型エラーは即フィードバックされる）+ 設定ファイルの構文検証（YAML は yq、JSON は node、compose ファイルは `docker compose config` によるスキーマ検証。構文エラーは編集時点でブロックされる）
 - `.env` / `certs/` / `mise.toml` / `package-lock.json` の編集ブロック（フック + `permissions.deny` の二層。ガードレールであり完全な境界ではない）
 - main ブランチへの直接コミット・強制 push のブロック（PreToolUse フックで即時検知、`.husky/pre-commit` / `.husky/pre-push` が実行時点で強制）
-- フック変更時は `.claude/hooks/run-tests.sh` でリグレッションテストを実行する
+- フック変更時は `.claude/hooks/run-tests.sh` でリグレッションテストを実行する（CI の `Claude Code Hooks` ジョブでも毎 push 実行される）
 
 ## ドキュメント
 


### PR DESCRIPTION
## 概要

Sonnet / Opus モデルでの今後の実装・リファクタリングを支援するため、Claude Code ハーネス（Hooks / Skills / Agents / CI）を拡充する。

## 変更点

### Hooks
- `post-edit.sh`: 設定ファイルの構文検証を追加。YAML は `yq`、JSON は `node`（JSONC な `tsconfig*` / `.vscode` は除外）、compose ファイルは `docker compose config -q` によるスキーマ検証まで実施。構文エラーは編集時点で exit 2 ブロック、検証ツール不在時はフェイルオープン。従来 Prettier がパース不能ファイルを黙って素通ししていた穴を塞ぐ
- node_modules 不在でも構文検証が動くよう早期 return を除去（レビュー指摘対応）
- `run-tests.sh`: 上記のリグレッションテスト 8 件を追加（計 37 件）

### Skills（新規 2 件）
- `cross-service-contracts`: 型で繋がっていないサービス間契約の連動箇所マップ（Kafka トピック ↔ Event Gateway ACL、Kong ルートパス ↔ フロントのハードコードパス、`X-User-*` ヘッダ、他サービスが fetch する Prisma フィールド、ポータル OAS の手動同期等）。Explore エージェントによる実地調査に基づく。サービス境界をまたぐリファクタリングの事前チェックリスト
- `create-pr`: 検証 → code-reviewer レビュー → セマンティックコミット → `gh pr create` のフロー標準化

### Agents / CLAUDE.md / CI
- `implementer` / `code-reviewer` に cross-service-contracts スキルへの参照を配線（境界をまたぐ片側更新漏れを Critical 扱いに）
- CLAUDE.md へ新スキル・フック新挙動を登録
- CI に `hooks` ジョブを追加（毎 push で `run-tests.sh` を実行）

## テスト結果

- `bash .claude/hooks/run-tests.sh` → **37/37 pass**（構文検証は TDD で RED → GREEN を確認）
- `npm run format:check` → 対象ファイルすべて pass（警告は未追跡の `.superpowers/sdd/` のみで対象外）
- `docker compose config -q` → pass
- スキル効果検証: Kafka トピックリネーム課題を Sonnet サブエージェントでベースライン / スキルあり比較。スキルありは Event Gateway ACL（default-deny）、`packages/shared` の死蔵定数の罠、ロールアウト順序リスクまで確実にカバー
- code-reviewer エージェントによるレビュー実施済み（Critical / Warning ゼロ。Nit 1 件は修正済み、tsc hoisting 依存の指摘は既存前提のためスコープ外）

## Konnect 反映の要否

不要（`config/kong/kong.yaml` / `kongctl/` は変更していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)