### PR TITLE
feat: AI チャットをログイン必須にする

### DIFF
--- a/config/kong/kong.yaml
+++ b/config/kong/kong.yaml
@@ -420,6 +420,19 @@ plugins:
     service: user-service
     config: *oidc_config
 
+  # OpenID Connect on Agent（AI チャットはログイン必須。/api/agent/* を保護）
+  - name: openid-connect
+    service: agent-service
+    config: *oidc_config
+
+  # OpenID Connect on Agent chat boundary（/ai/agent-chat/v1 = フロントのチャット completion）
+  # ルート単位で付与する。openid-connect（access フェーズ）が受信 Bearer(Keycloak JWT) を
+  # 先に検証し、その後 ai-proxy-advanced が upstream（agent）向けに Authorization を
+  # OpenAI キーへ差し替える。/ai/v1（curl デモ）と /ai/agent/v1（内部）は無認証のまま。
+  - name: openid-connect
+    route: openai-agent-boundary-route
+    config: *oidc_config
+
   # Stricter Rate Limiting on Order
   - name: rate-limiting
     service: order-service

--- a/guides/agent-api.md
+++ b/guides/agent-api.md
@@ -4,6 +4,8 @@ AI チャットエージェントの API です。Volcano Agent SDK を使用し
 
 Base URL: `http://localhost:8000/api/agent`
 
+> **認証（ログイン必須）**: `/api/agent/*` と `/ai/agent-chat/v1` は Keycloak SSO（OIDC/JWT）で保護されています。ブラウザ経路はフロントエンドの `/api/proxy` がログインセッションのアクセストークンを `Authorization: Bearer` として自動付与します。curl から呼ぶ場合は有効なアクセストークンを `Authorization: Bearer <access_token>` で渡してください（未認証は `401`）。cart/order 等の `/admin/api/*`（API キー）のような curl 用バイパス経路は agent には用意していません。
+
 ## アーキテクチャ
 
 ```
@@ -30,6 +32,7 @@ Base URL: `http://localhost:8000/api/agent`
 ```bash
 curl -X POST http://localhost:8000/ai/agent-chat/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <access_token>" \
   -d '{
     "model": "gpt-4o-mini",
     "messages": [
@@ -69,7 +72,8 @@ OpenAI の chat completion 形式で返却されます。回答本文は `choice
 ユーザーに表示する質問候補を返します。
 
 ```bash
-curl http://localhost:8000/api/agent/suggestions
+curl http://localhost:8000/api/agent/suggestions \
+  -H "Authorization: Bearer <access_token>"
 ```
 
 ### レスポンス例

--- a/services/frontend/src/components/AskAIDialog.tsx
+++ b/services/frontend/src/components/AskAIDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react'
 import Markdown from 'react-markdown'
 import { apiFetch } from '@/lib/api'
 import { buildChatCompletionRequest, type ChatMessage } from '@/lib/chat'
+import { useAuthUser } from '@/lib/auth'
 
 type Message = ChatMessage
 
@@ -16,6 +17,7 @@ interface SuggestionsResponse {
 }
 
 export default function AskAIDialog() {
+  const { status } = useAuthUser()
   const [open, setOpen] = useState(false)
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
@@ -97,6 +99,10 @@ export default function AskAIDialog() {
       sendMessage()
     }
   }
+
+  // AI チャットはログイン必須。未認証（RefreshTokenError 含む）では FAB を出さない。
+  // バックエンド側も Kong の openid-connect で agent 系ルートを保護している（多層防御）。
+  if (status !== 'authenticated') return null
 
   return (
     <>

--- a/services/frontend/src/components/__tests__/AskAIDialog.test.tsx
+++ b/services/frontend/src/components/__tests__/AskAIDialog.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// useSession をモックすれば useAuthUser 経由のゲートを検証できる。
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}))
+// react-markdown は ESM のため、テストでは素通しにモックしてインポートを安定させる。
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => children,
+}))
+
+import { useSession } from 'next-auth/react'
+import AskAIDialog from '../AskAIDialog'
+
+const mockedUseSession = vi.mocked(useSession)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AskAIDialog 認証ゲート', () => {
+  it('未認証のときは何も描画しない（FAB を表示しない）', () => {
+    mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' } as never)
+    const html = renderToStaticMarkup(<AskAIDialog />)
+    expect(html).toBe('')
+  })
+
+  it('認証済みのときは FAB を描画する', () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        user: { id: 'kc-sub-123', email: 'jack@example.com', name: 'Jack Driscoll' },
+        expires: '2999-01-01',
+      },
+      status: 'authenticated',
+    } as never)
+    const html = renderToStaticMarkup(<AskAIDialog />)
+    expect(html).toContain('ask-ai-fab')
+  })
+
+  it('RefreshTokenError のセッションは未認証扱いで描画しない', () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        user: { id: 'kc-sub-123', email: 'jack@example.com', name: 'Jack Driscoll' },
+        error: 'RefreshTokenError',
+        expires: '2999-01-01',
+      },
+      status: 'authenticated',
+    } as never)
+    const html = renderToStaticMarkup(<AskAIDialog />)
+    expect(html).toBe('')
+  })
+})

--- a/services/frontend/vitest.config.ts
+++ b/services/frontend/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
   },
+  // Next/React 19 と同じ automatic JSX ランタイムを使う（tsx コンポーネントは
+  // React を import しないため、classic ランタイムだと "React is not defined" になる）。
+  esbuild: {
+    jsx: 'automatic',
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## 概要

AI チャット（`AskAIDialog`）が**未ログインでも利用できてしまう**問題を、多層防御（フロント UX ゲート + Kong による API 保護）で修正します。

### 背景（原因）

1. **フロント**: `AskAIDialog` が `layout.tsx` でグローバルにマウントされ、`useAuthUser()` ゲートが無かった（cart/orders はゲート済みなのにチャットの FAB だけ常時表示）。
2. **Kong**: `openid-connect` が cart/order/shipping/user サービスには付与されていたが、**agent-service と `/ai/agent-chat/v1` 境界ルートには無く**、`/api/proxy` 経由・curl 直叩きの未認証リクエストが通っていた。

## 変更内容

1. **フロント（`AskAIDialog.tsx`）**: `useAuthUser()` を追加し、`status !== 'authenticated'`（`RefreshTokenError` 含む）のとき `null` を返して FAB を描画しない。全 hooks の後に early return を置きフック順序を維持。未ログインでは suggestions / chat の呼び出しも発生しない。
2. **Kong（`config/kong/kong.yaml`）**: 既存 `*oidc_config`（bearer）を `agent-service`（`/api/agent/*`）と `openai-agent-boundary-route`（`/ai/agent-chat/v1`）へ付与。`/ai/v1`（curl 一問一答デモ）・`/ai/agent/v1`（エージェント内部呼び出し）は**無認証のまま維持**。
3. **テスト（新規 `AskAIDialog.test.tsx`）**: `react-dom/server` の `renderToStaticMarkup` + `useSession` モックで、未認証→`null` / 認証済→FAB / `RefreshTokenError`→`null` を検証（依存追加なし）。`vitest.config.ts` に automatic JSX ランタイム設定を追加。
4. **docs（`guides/agent-api.md`）**: 認証必須の注記と curl 例への `Authorization: Bearer` を反映。

## データフロー

- **ログイン時**: FAB 表示 → `/api/proxy` が Bearer JWT 付与 → Kong OIDC 検証（境界ルートはその後 ai-proxy-advanced が Authorization を OpenAI キーへ差し替え）→ 応答。
- **未ログイン**: FAB 非表示。curl 直叩きでも Kong が **401**。

## テスト結果

| 検証 | 結果 |
|---|---|
| フロント型チェック（`tsc -p services/frontend`） | ✅ エラーなし |
| フロントテスト（`vitest`） | ✅ 38 passed（新規 3 件含む） |
| Kong 構成検証（`deck file validate`） | ✅ exit 0 |
| OIDC 付与範囲（`yq`） | ✅ agent-service + 境界ルートのみ（/ai/v1 は無認証維持） |
| フォーマット（prettier） | ✅ All files formatted correctly |
| コードレビュー（code-reviewer） | ✅ Critical なし。Warning（agent-api.md の curl 401 化）を反映済み |

## マージ後に必要な作業

- **`mise run gateway:sync`（ユーザー実行、要 diff 承認）**: Kong 側の OIDC 保護はこの sync で有効化されます。
- **スモークテスト（sync 後）**: ①ログイン状態でチャット成功（suggestions + chat completion）、②未認証 curl で `/api/agent/suggestions`・`/ai/agent-chat/v1/chat/completions` が 401、③`/ai/v1` は従来どおり無認証で動作。

## 補足

- 設計 spec はローカル `docs/superpowers/specs/2026-07-08-require-login-for-chat-design.md` に保持（`docs/` は `.gitignore` 対象のため未コミット）。
- agent には curl 用の `/admin` key-auth 経路を追加していません（「ログイン必須」の意図を保つため）。curl は有効な JWT が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)