### PR TITLE
chore: Konnect/Gateway 適用前に差分を確認できる mise タスクを追加

### DIFF
--- a/.claude/skills/sync-konnect/SKILL.md
+++ b/.claude/skills/sync-konnect/SKILL.md
@@ -10,28 +10,25 @@ disable-model-invocation: true
 
 ## 対象の切り分け
 
-| 変更したファイル        | 反映コマンド                         | 対象                             |
-| ----------------------- | ------------------------------------ | -------------------------------- |
-| `config/kong/kong.yaml` | `mise run gateway:sync`（decK）      | Gateway の service/route/plugin  |
-| `kongctl/*.yaml`        | `cd kongctl && kongctl sync konnect` | API、Portal、Event Gateway、Team |
+| 変更したファイル        | diff タスク             | sync タスク                                          | 対象                             |
+| ----------------------- | ----------------------- | ---------------------------------------------------- | -------------------------------- |
+| `config/kong/kong.yaml` | `mise run gateway:diff` | `mise run gateway:sync`（decK）                      | Gateway の service/route/plugin  |
+| `kongctl/*.yaml`        | `mise run konnect:diff` | `mise run konnect:sync`（kongctl、`--auto-approve`） | API、Portal、Event Gateway、Team |
+
+diff タスクは読み取り専用（適用しない）。sync タスクと同じ認証・env 供給ロジック（`.mise/lib/common.sh` の `setup_konnect_pat` 等）を共有するため、素の `deck` / `kongctl` コマンドを直接叩くより確実。
 
 ## 手順（Gateway 設定: kong.yaml）
 
-1. 変更内容の diff を確認:
-
-   ```bash
-   deck gateway diff config/kong/kong.yaml \
-     --konnect-control-plane-name jungle-store-gateway
-   ```
-
+1. 変更内容の diff を確認: `mise run gateway:diff`
 2. diff をユーザーに提示し、適用の承認を得る。
 3. 承認後: `mise run gateway:sync`
 4. 反映確認: `/verify-stack` の手順 3（Kong 経由のリクエスト）で動作検証。
 
 ## 手順（Konnect リソース: kongctl/）
 
-1. `cd kongctl && kongctl plan konnect` で差分を確認（plan がない場合は sync の dry-run 相当の出力を確認）。
-2. ユーザー承認後: `kongctl sync konnect`
+1. 変更内容の diff を確認: `mise run konnect:diff`
+2. diff をユーザーに提示し、適用の承認を得る。
+3. 承認後: `mise run konnect:sync`（内部で `--auto-approve` を使うため、kongctl 自体の対話確認は出ない。承認は手順 2 で得ておくこと）
 
 ## 注意
 

--- a/.mise/tasks/gateway/diff
+++ b/.mise/tasks/gateway/diff
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#MISE description="deck で Gateway 設定の差分を表示（適用はしない）"
+set -euo pipefail
+source "$(git rev-parse --show-toplevel)/.mise/lib/common.sh"
+setup_konnect_pat
+# deck のテンプレート変数を .env から環境へ供給する（gateway:sync と同じ理由で自己完結させる）
+export DECK_KEYCLOAK_ISSUER="$(env_get DECK_KEYCLOAK_ISSUER)"
+export DECK_OPENAI_API_KEY="$(env_get DECK_OPENAI_API_KEY)"
+cp_name="$(env_get DECK_KONNECT_CONTROL_PLANE_NAME)"; cp_name="${cp_name:-jungle-store-gateway}"
+deck gateway diff "$REPO_ROOT/config/kong/kong.yaml" \
+  --konnect-control-plane-name "$cp_name"

--- a/.mise/tasks/konnect/diff
+++ b/.mise/tasks/konnect/diff
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Konnect リソースの差分を表示（適用はしない）"
+set -euo pipefail
+source "$(git rev-parse --show-toplevel)/.mise/lib/common.sh"
+setup_konnect_pat
+
+SRC="$(bash "$REPO_ROOT/.mise/lib/render-kongctl.sh")"
+log "kongctl source: $SRC"
+
+# 証明書 PEM を同期ソース配下 .certs/ にステージ（YAML の !file .certs/... が参照）
+mkdir -p "$SRC/.certs"
+cp "$REPO_ROOT/certs/kong-gateway/cluster.crt"  "$SRC/.certs/kong-gateway.crt"
+cp "$REPO_ROOT/certs/event-gateway/cluster.crt" "$SRC/.certs/event-gateway.crt"
+
+kongctl diff -f "$SRC"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,13 @@ docker compose config -q                     # compose.yaml の構文検証
 ### Kong / Konnect への設定反映
 
 ```bash
+mise run gateway:diff              # config/kong/kong.yaml の適用前差分を表示（適用はしない）
 mise run gateway:sync              # config/kong/kong.yaml を decK で同期（CP: jungle-store-gateway）
-cd kongctl && kongctl sync konnect # API / Portal / Event Gateway 等の Konnect リソースを同期
+mise run konnect:diff              # kongctl/ の適用前差分を表示（適用はしない）
+mise run konnect:sync              # API / Portal / Event Gateway 等の Konnect リソースを同期（--auto-approve）
 ```
 
-いずれも外部環境を変更する操作。実行前に diff（`deck gateway diff` / `kongctl plan`）をユーザーに提示して承認を得ること。詳細は `/sync-konnect` スキル参照。
+いずれも sync は外部環境を変更する操作。実行前に対応する `diff` タスクの出力をユーザーに提示して承認を得ること。詳細は `/sync-konnect` スキル参照。
 
 ### 1コマンドセットアップ（`mise run setup`）
 


### PR DESCRIPTION
## 概要

`mise run gateway:sync` / `mise run konnect:sync` は適用前の diff 確認が手順書（`/sync-konnect` スキル）頼みで、mise タスクとしては存在しなかった。適用前に差分を可視化できる読み取り専用タスクを追加した。

## 変更点

- `.mise/tasks/gateway/diff`（新規）: `deck gateway diff` を実行。`gateway/sync` と同じ認証・env 供給ロジックを共有（適用はしない）
- `.mise/tasks/konnect/diff`（新規）: `kongctl diff -f "$SRC"` を実行。`konnect/sync` と同じ認証・レンダリング・証明書ステージングロジックを共有（適用はしない）
- `konnect:sync` の `--auto-approve` は据え置き（変更なし、ユーザー指示）
- `CLAUDE.md` / `.claude/skills/sync-konnect/SKILL.md`: 生の `deck` / `kongctl` コマンドから新タスク経由の手順に更新

## テスト結果

- `mise run gateway:diff` を実環境（CP: jungle-store-gateway）に対して実行 → `Created: 0 / Updated: 0 / Deleted: 0`（既知の未反映差分なし、正常応答を確認）
- `mise run konnect:diff` を実環境に対して実行 → 実際に未反映の差分2件（`portal_page:home`、`event_gateway_backend_cluster:jungle-store-kafka`）を正しく検出
- `mise tasks ls` で `gateway:diff` / `konnect:diff` が正しく登録されることを確認
- `bash -n` で両スクリプトの構文チェック → OK
- `prettier --check`（`CLAUDE.md` / `SKILL.md`）→ 問題なし
- `code-reviewer` サブエージェントによるレビュー → Critical/Warning なし
- 未検証: `npm run test` / `npx tsc --noEmit`（バックエンドサービスのコード変更なしのため対象外）

## Konnect 反映の要否

`config/kong/kong.yaml` / `kongctl/` は変更していないため、マージ後の `/sync-konnect` 実行は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)