### PR TITLE
fix: portals.yaml の customization キー重複を解消

### DIFF
--- a/kongctl/portals.yaml
+++ b/kongctl/portals.yaml
@@ -26,12 +26,6 @@ portals:
           primary: '#CCFF00'
       css: !file portals/theme.css
 
-    customization:
-      theme:
-        mode: dark
-        colors:
-          primary: '#CCFF00'
-
     pages:
       - ref: home
         slug: /


### PR DESCRIPTION
## 概要

`kongctl sync konnect` が `kongctl/portals.yaml` のYAMLパースエラーで失敗する不具合の修正。

## 原因

#57（デモ実施者ガイド追加PR）のブランチが、#56（Dev Portal ダークテーマ刷新、`customization` ブロック追加）より前の古い `main` から分岐していた。#57 の worktree には、#56 とは別に作業されていた（未commitのまま残っていた）簡易版の `customization` ブロックが存在し、#57 の最初のコミットとしてそのまま取り込まれてしまった。

結果として `main` マージ後、`portals.yaml` に `customization:` キーが2つ存在する状態になり、YAML パーサ（kongctl 内部の go-yaml）が `key "customization" already set in map` でエラーになっていた。

## 変更内容

`kongctl/portals.yaml` から、後から重複して入った簡易版の `customization` ブロック（`ref` と `css` を持たない方）を削除。#56 由来の完全版（`ref: jungle-store-dev-portal-customization` / `css: !file portals/theme.css` 付き）のみを残す。

## テスト結果

- `yq eval '.' kongctl/portals.yaml` — 実行、エラーなし（YAML として正しくパース可能）
- `yq eval '.portals[0].customization' kongctl/portals.yaml` — 実行、重複なく単一の customization ブロックが返ることを確認
- `yq eval '.portals[0].pages[] | select(.ref == "demos") | .children | length' kongctl/portals.yaml` — 実行、`6`（#57 で追加したデモページツリーが無傷であることを確認）
- `mise run konnect:sync` の実機実行は未検証（Konnect への実反映はユーザー判断のため）

## Konnect 反映の要否

`kongctl/` を変更しているため、**マージ後に `/sync-konnect`（ユーザー実行）が必要**。むしろ本PRは、現在 main で失敗している `kongctl sync konnect` を再び動かせるようにするための修正。