### PR TITLE
chore: APIカタログ・利用者ガイドを未ログインで公開

### DIFF
--- a/kongctl/portals.yaml
+++ b/kongctl/portals.yaml
@@ -37,14 +37,14 @@ portals:
         slug: 'apis'
         title: 'APIs'
         description: 'API Products available in this Developer Portal.'
-        visibility: 'private'
+        visibility: 'public'
         status: 'published'
         content: !file portals/pages/apis.md
       - ref: guides
         slug: 'guides'
         title: 'Guides'
         description: 'Guide for Developer Portal'
-        visibility: 'private'
+        visibility: 'public'
         status: 'published'
         content: !file portals/pages/guides/guides.md
         children:


### PR DESCRIPTION
## 概要

「デモ実施者ガイド」（#57）と同様に、「APIカタログ」（`apis`）と「利用者ガイド」（`guides`）の上位ページも未ログインで閲覧できるようにする。

## 変更内容

`kongctl/portals.yaml` で `apis` / `guides` ページの `visibility` を `'private'` → `'public'` に変更（子ページは元々 `public` 済み）。

## テスト結果

- `yq eval '.' kongctl/portals.yaml` — 実行、エラーなし
- 差分は `visibility` の2箇所のみ

## Konnect 反映の要否

`kongctl/` を変更しているため、**マージ後に `/sync-konnect`（ユーザー実行）が必要**。