### PR TITLE
docs: GitHub リリース作成スキルを追加

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: release
+description: Use when the user wants to cut a GitHub Release for this repo — 「リリースして」「vX.Y.Zでリリース」「1.0.0としてリリース」等。バージョン番号を指定してタグ + GitHub Release を作成する。
+---
+
+# GitHub リリース作成フロー
+
+`main` の現時点のコミットに対して Git タグ + GitHub Release を作成する手順。`gh release create` は内部でタグ作成 + push を行うため、`git tag` / `git push --tags` を個別に叩く必要はない（このリポジトリの worktree では `git commit` / `git push` がフックで誤ブロックされることがあるが、`gh` コマンドはその対象外）。
+
+## 手順
+
+1. **バージョン確認**: ユーザーの発言からバージョン番号（SemVer, 例: `1.0.0`）を取得する。明示されていなければ確認する。タグ名はリポジトリの慣習に合わせ `v` プレフィックスを付ける（例: `1.0.0` → タグ `v1.0.0`）。
+
+2. **重複チェック**: 同名タグ/リリースが既に存在しないか確認する。
+
+   ```bash
+   gh release view vX.Y.Z 2>&1
+   ```
+
+   既に存在する場合はユーザーに確認する（上書き・別バージョン番号への変更など）。
+
+3. **リリース対象ブランチの健全性確認**: 通常は `main`。直近の CI が成功していることを確認する。
+
+   ```bash
+   gh run list --branch main --limit 1
+   ```
+
+   `failure` の場合はユーザーに知らせ、リリースを続行してよいか確認する（CI失敗を承知の上でのリリースは非推奨）。
+
+4. **リリース作成**: `--generate-notes` で直近リリース以降（初回は履歴全体）にマージされた PR からリリースノートを自動生成する。
+
+   ```bash
+   gh release create vX.Y.Z --target main --title "vX.Y.Z" --generate-notes
+   ```
+
+5. リリース URL をユーザーに報告する。
+
+## スコープ外
+
+- このスキルは GitHub Release の作成のみを行う。npm パッケージの publish、Docker イメージのビルド/push、Konnect への反映（`/sync-konnect`）等は別途必要であれば個別に実施する（本リポジトリはデモ用アプリケーションで npm publish 等は行わない）。
+- `main` 以外のブランチ・コミットを対象にしたい場合は `--target <branch-or-sha>` を明示する。
+
+## よくある間違い
+
+- タグ名の `v` プレフィックスを付け忘れる／ユーザー指定と食い違う → 手順1で確認する
+- CI が失敗した状態のコミットに気づかずリリースしてしまう → 手順3を必ず実施する
+- 既存タグと衝突して `gh release create` がエラーになる → 手順2で事前チェック

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ services/<名前>/src/
 - `create-pr` — 実装完了からの PR 作成フロー（検証 → code-reviewer レビュー → セマンティックコミット → gh pr create）
 - `verify-stack` — スタック全体のスモークテスト（ヘルスチェック、Kong プラグイン、Kafka フロー）
 - `sync-konnect` — Konnect への設定反映（ユーザー実行専用。diff → 承認 → sync）
+- `release` — GitHub リリース作成（バージョン確認 → CI 健全性確認 → タグ + Release 作成）
 - `kongctl-declarative` / `kongctl-extension-builder` — kongctl CLI が配布する公式スキル（実体は `.claude/skills/` 配下、`.agents/skills/` からシンボリックリンク。kongctl での再インストール時は配置先に注意）
 
 ### サブエージェント（.claude/agents/）


### PR DESCRIPTION
## 概要

GitHub Release を作成する作業（今回 v1.0.0 をリリース）を今後も繰り返し依頼される想定のため、`.claude/skills/release/` としてスキル化した。

## 変更内容

- `.claude/skills/release/SKILL.md` — バージョン確認 → 重複タグチェック → CI 健全性確認 → `gh release create --generate-notes` の手順を定義
- `CLAUDE.md` — スキル一覧に `release` を追記

## テスト結果

- ドキュメント/スキル定義のみの変更のためコード検証は対象外
- `npm run format:check` — 実行、対象ファイルに整形問題なし

## Konnect 反映の要否

不要（`kongctl/` / `config/kong/` の変更なし）