### PR TITLE
feat: GitHub Release publish 時に GHCR へコンテナイメージを公開し、デフォルト起動を高速化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ MYSQL_PORT=3306
 # Kafka
 KAFKA_BROKER=kafka:9092
 
+# Container Images (release)
+# docker compose up -d（--build なし）は GHCR の公開イメージを pull して起動する。
+# 未指定時は compose.yaml のデフォルトタグ（最新リリース）を使う。特定バージョンに固定したい場合のみ上書きする。
+# IMAGE_TAG=v1.0.0
+
 # Kong
 # Konnect Personal Access Token（deck と kongctl が共用。Konnect の Personal Access Tokens から発行）
 # mise が .env を読み込み、各タスクの setup_konnect_pat が deck 用に DECK_KONNECT_TOKEN、kongctl 用に KONGCTL_DEFAULT_KONNECT_PAT として供給する

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-push:
+    name: Build & Push (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: catalog-service
+            dockerfile: services/catalog-service/Dockerfile
+          - name: cart-service
+            dockerfile: services/cart-service/Dockerfile
+          - name: order-service
+            dockerfile: services/order-service/Dockerfile
+          - name: shipping-service
+            dockerfile: services/shipping-service/Dockerfile
+          - name: user-service
+            dockerfile: services/user-service/Dockerfile
+          - name: agent-service
+            dockerfile: services/agent-service/Dockerfile
+          - name: frontend
+            dockerfile: services/frontend/Dockerfile
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/shukawam/konnect-entire-demo-${{ matrix.name }}:${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ Kong Konnect デモ用 EC サイト。ゴリラをテーマにした e コマー
 
 ### 全サービス起動
 
-デフォルト（`--build` なし）は GHCR の公開イメージ（`ghcr.io/shukawam/konnect-entire-demo-<service>`）を pull して起動する（ローカルビルドを省略するため高速）。バージョンは `.env` の `IMAGE_TAG`（例: `IMAGE_TAG=v1.0.0`）で切り替えられる。
+デフォルト（`--build` なし）は GHCR の公開イメージ（`ghcr.io/shukawam/konnect-entire-demo-<service>`）を pull して起動する（ローカルビルドを省略するため高速）。バージョンは `.env` の `IMAGE_TAG`（例: `IMAGE_TAG=v1.0.0`）で切り替えられる。同じタグのイメージが既にローカルにある場合は自動では再 pull されないため、更新したい場合は `docker compose pull` を実行する。
 
 ```bash
 docker compose up -d
 ```
 
-ソースの変更をコンテナに反映したい開発時は `--build` を付けてローカルビルドする（従来通りの挙動）。
+初回リリース（GitHub Release の publish）が行われるまでは GHCR にイメージが存在しないため上記は pull に失敗する。それまで、およびソースの変更をコンテナに反映したい開発時は `--build` を付けてローカルビルドする（従来通りの挙動）。
 
 ```bash
 docker compose up -d --build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ Kong Konnect デモ用 EC サイト。ゴリラをテーマにした e コマー
 
 ### 全サービス起動
 
+デフォルト（`--build` なし）は GHCR の公開イメージ（`ghcr.io/shukawam/konnect-entire-demo-<service>`）を pull して起動する（ローカルビルドを省略するため高速）。バージョンは `.env` の `IMAGE_TAG`（例: `IMAGE_TAG=v1.0.0`）で切り替えられる。
+
+```bash
+docker compose up -d
+```
+
+ソースの変更をコンテナに反映したい開発時は `--build` を付けてローカルビルドする（従来通りの挙動）。
+
 ```bash
 docker compose up -d --build
 ```

--- a/README.en.md
+++ b/README.en.md
@@ -122,7 +122,7 @@ RESOURCE_PREFIX=e2e mise run teardown  # cleanup (delete Konnect resources + com
 To control Konnect resource creation/sync yourself, or to operate an already-running stack, use these commands (for the Konnect / Gateway sync steps, see the "Applying config to Kong / Konnect" section in [CLAUDE.md](CLAUDE.md)).
 
 ```bash
-# Start all services (default pulls the published GHCR image, so it's fast; pass --build to build from source)
+# Start all services (default pulls the published GHCR image, so it's fast; before the first release exists, or during development, pass --build to build from source)
 docker compose up -d
 
 # Check status
@@ -407,7 +407,9 @@ Changes under each service's `src/` are auto-synced to containers. Changes to `p
 
 ### Container Images / Release Process
 
-`docker compose up -d` (without `--build`) pulls the published image from GHCR (`ghcr.io/shukawam/konnect-entire-demo-<service>`) by default. To pin a specific version, set `IMAGE_TAG=vX.Y.Z` in `.env`.
+`docker compose up -d` (without `--build`) pulls the published image from GHCR (`ghcr.io/shukawam/konnect-entire-demo-<service>`) by default. To pin a specific version, set `IMAGE_TAG=vX.Y.Z` in `.env`. If a local image with the same tag already exists, it is not automatically re-pulled — run `docker compose pull` to refresh it.
+
+> **Note:** Until the first release is published, no image exists in GHCR yet, so `docker compose up -d` (without `--build`) will fail to pull. Use `docker compose up -d --build` until then.
 
 To release a new version:
 

--- a/README.en.md
+++ b/README.en.md
@@ -122,8 +122,8 @@ RESOURCE_PREFIX=e2e mise run teardown  # cleanup (delete Konnect resources + com
 To control Konnect resource creation/sync yourself, or to operate an already-running stack, use these commands (for the Konnect / Gateway sync steps, see the "Applying config to Kong / Konnect" section in [CLAUDE.md](CLAUDE.md)).
 
 ```bash
-# Start all services (first build takes a few minutes)
-docker compose up -d --build
+# Start all services (default pulls the published GHCR image, so it's fast; pass --build to build from source)
+docker compose up -d
 
 # Check status
 docker compose ps
@@ -404,6 +404,17 @@ docker compose watch
 ```
 
 Changes under each service's `src/` are auto-synced to containers. Changes to `package.json` or `prisma/schema.prisma` trigger an automatic rebuild.
+
+### Container Images / Release Process
+
+`docker compose up -d` (without `--build`) pulls the published image from GHCR (`ghcr.io/shukawam/konnect-entire-demo-<service>`) by default. To pin a specific version, set `IMAGE_TAG=vX.Y.Z` in `.env`.
+
+To release a new version:
+
+1. Open and merge a PR that bumps the `image:` default tag (`${IMAGE_TAG:-vX.Y.Z}`) for each app service in `compose.yaml`
+2. Create and publish a GitHub Release on the merged commit, tagged `vX.Y.Z` (matching the value bumped in step 1)
+3. `.github/workflows/release.yml` runs and builds/pushes all 7 service images to GHCR
+4. (Only the first time a new package is created) switch its visibility to Public in the GHCR package settings
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ RESOURCE_PREFIX=e2e mise run teardown  # 後始末（Konnect リソース削除 
 Konnect リソースの作成・同期を自分でコントロールしたい場合、または起動済みのスタックを個別に操作したい場合は次のコマンドを使います（Konnect / Gateway の同期手順は [CLAUDE.md](CLAUDE.md) の「Kong / Konnect への設定反映」節を参照）。
 
 ```bash
-# 全サービス起動（デフォルトは GHCR の公開イメージを pull するだけなので高速。ソースからビルドしたい場合は --build を付ける）
+# 全サービス起動（デフォルトは GHCR の公開イメージを pull するだけなので高速。初回リリース前や開発時など、GHCR にイメージが無い/ソースからビルドしたい場合は --build を付ける）
 docker compose up -d
 
 # ステータス確認
@@ -425,7 +425,9 @@ docker compose watch
 
 ### コンテナイメージ / リリース手順
 
-`docker compose up -d`（`--build` なし）はデフォルトで GHCR（`ghcr.io/shukawam/konnect-entire-demo-<service>`）の公開イメージを pull して起動する。特定バージョンに固定したい場合は `.env` に `IMAGE_TAG=vX.Y.Z` を設定する。
+`docker compose up -d`（`--build` なし）はデフォルトで GHCR（`ghcr.io/shukawam/konnect-entire-demo-<service>`）の公開イメージを pull して起動する。特定バージョンに固定したい場合は `.env` に `IMAGE_TAG=vX.Y.Z` を設定する。同じタグのイメージが既にローカルにある場合は自動では再 pull されないため、更新したい場合は `docker compose pull` を実行する。
+
+> **注意:** 初回リリースが publish されるまでは GHCR にイメージが存在しないため、`docker compose up -d`（`--build` なし）は pull に失敗する。それまでは `docker compose up -d --build` を使うこと。
 
 新しいバージョンをリリースする手順:
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ RESOURCE_PREFIX=e2e mise run teardown  # 後始末（Konnect リソース削除 
 Konnect リソースの作成・同期を自分でコントロールしたい場合、または起動済みのスタックを個別に操作したい場合は次のコマンドを使います（Konnect / Gateway の同期手順は [CLAUDE.md](CLAUDE.md) の「Kong / Konnect への設定反映」節を参照）。
 
 ```bash
-# 全サービス起動（初回はビルドに数分かかります）
-docker compose up -d --build
+# 全サービス起動（デフォルトは GHCR の公開イメージを pull するだけなので高速。ソースからビルドしたい場合は --build を付ける）
+docker compose up -d
 
 # ステータス確認
 docker compose ps
@@ -422,6 +422,17 @@ docker compose watch
 ```
 
 各サービスの `src/` 配下の変更はコンテナへ自動同期され、`package.json` や `prisma/schema.prisma` の変更時は自動リビルドされます。
+
+### コンテナイメージ / リリース手順
+
+`docker compose up -d`（`--build` なし）はデフォルトで GHCR（`ghcr.io/shukawam/konnect-entire-demo-<service>`）の公開イメージを pull して起動する。特定バージョンに固定したい場合は `.env` に `IMAGE_TAG=vX.Y.Z` を設定する。
+
+新しいバージョンをリリースする手順:
+
+1. `compose.yaml` の各アプリサービスの `image:` デフォルトタグ（`${IMAGE_TAG:-vX.Y.Z}`）を新しいバージョンにバンプする PR を作成・マージする
+2. マージ後のコミットに対して GitHub Release を作成し、1 でバンプした値と同じ `vX.Y.Z` タグを付けて publish する
+3. `.github/workflows/release.yml` が起動し、7 サービスのイメージをビルドして GHCR に push する
+4. （新しいパッケージが初めて作成された場合のみ）GHCR のパッケージ設定で可視性を Public に切り替える
 
 ## トラブルシューティング
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -272,6 +272,7 @@ services:
   catalog-service:
     <<: *default
     container_name: catalog-service
+    image: ghcr.io/shukawam/konnect-entire-demo-catalog-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/catalog-service/Dockerfile
@@ -313,6 +314,7 @@ services:
   cart-service:
     <<: *default
     container_name: cart-service
+    image: ghcr.io/shukawam/konnect-entire-demo-cart-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/cart-service/Dockerfile
@@ -349,6 +351,7 @@ services:
   order-service:
     <<: *default
     container_name: order-service
+    image: ghcr.io/shukawam/konnect-entire-demo-order-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/order-service/Dockerfile
@@ -390,6 +393,7 @@ services:
   shipping-service:
     <<: *default
     container_name: shipping-service
+    image: ghcr.io/shukawam/konnect-entire-demo-shipping-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/shipping-service/Dockerfile
@@ -429,6 +433,7 @@ services:
   user-service:
     <<: *default
     container_name: user-service
+    image: ghcr.io/shukawam/konnect-entire-demo-user-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/user-service/Dockerfile
@@ -470,6 +475,7 @@ services:
   agent-service:
     <<: *default
     container_name: agent-service
+    image: ghcr.io/shukawam/konnect-entire-demo-agent-service:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/agent-service/Dockerfile
@@ -504,6 +510,7 @@ services:
   frontend:
     <<: *default
     container_name: frontend
+    image: ghcr.io/shukawam/konnect-entire-demo-frontend:${IMAGE_TAG:-v1.0.0}
     build:
       context: .
       dockerfile: services/frontend/Dockerfile


### PR DESCRIPTION
## 概要

GitHub Release（`vX.Y.Z` タグ）を publish すると、7 サービス分のコンテナイメージが GHCR（`ghcr.io/shukawam/konnect-entire-demo-<service>`）に自動公開されるようにした。`docker compose up -d`（`--build` なし）はデフォルトでこの公開イメージを pull して起動するため、毎回のローカルビルドが不要になり起動が速くなる。`.env` の `IMAGE_TAG` で任意バージョンに切り替え可能。実行モード（`tsx watch` / `next dev` などの `command:`）は変更していない。

設計/計画: `docs/superpowers/specs/2026-07-10-release-container-images-design.md` / `docs/superpowers/plans/2026-07-10-release-container-images.md`（`docs/` は本リポジトリの規約でコミット対象外のためリンクなし）

## 変更点

- `.github/workflows/release.yml`（新規）: `release: published` で 7 サービスを matrix ビルドし GHCR へ push（multi-arch: `linux/amd64,linux/arm64`、QEMU セットアップ込み）
- `compose.yaml`: 7 アプリサービスに `image: ghcr.io/shukawam/konnect-entire-demo-<service>:${IMAGE_TAG:-v1.0.0}` を追加（既存 `build:` は維持。Compose のデフォルト挙動＝pull 優先・無ければ build を利用）
- `.env.example`: `IMAGE_TAG` の説明を追加
- `CLAUDE.md` / `README.md` / `README.en.md`: `--build` の有無による挙動差、リリース手順（バンプ PR → GitHub Release publish → CI 自動ビルド → 初回のみ GHCR 可視性を Public に切替）、初回リリース前は `--build` が必要な旨、pull の再取得挙動の注意点を追記

## リリース手順（今後の運用）

1. `compose.yaml` の各サービスの `image:` デフォルトタグをバンプする PR を作成・マージ
2. マージ後のコミットに対して GitHub Release を作成し、同じ `vX.Y.Z` タグで publish
3. `.github/workflows/release.yml` が自動でビルド・push
4. （新しい GHCR パッケージが初めて作られた時のみ）パッケージ設定で可視性を Public に切替（`GITHUB_TOKEN` では自動化不可のため手動）

## テスト結果

- `npm run test`（全ワークスペース）: 全テストパス
- `npm run format:check`（変更ファイルのみ個別確認: compose.yaml / CLAUDE.md / README.md / README.en.md / release.yml）: 問題なし（`.env.example` は Prettier 対象外拡張子のため no-op）
- `docker compose config -q`: 構文エラーなし
- `.github/workflows/release.yml` の YAML 構文: `yq eval` で確認済み
- **未検証**: 実際の GitHub Release publish → GHCR へのビルド・push → `docker compose up -d` での pull 起動は、初回リリースが存在しないため未実施（ユーザーによる初回リリース後に実機検証が必要）

## Konnect 反映の要否

`config/kong/kong.yaml` / `kongctl/` は変更していないため不要。

## レビュー

subagent-driven-development で 6 タスクを個別実装・個別レビュー（各タスク spec compliance ✅）した上で、最終的にブランチ全体レビュー（opus）を実施。Important 指摘2件（初回リリース前の `--build` 案内漏れ、pull の再取得挙動の説明不足）を修正し、再レビューで "Ready to merge: Yes" の判定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)