### PR TITLE
chore: Keycloakデモユーザー(jack/carl)のUUIDをrealm-export.jsonに固定

### DIFF
--- a/config/keycloak/realm-export.json
+++ b/config/keycloak/realm-export.json
@@ -29,6 +29,7 @@
   "sslRequired": "none",
   "users": [
     {
+      "id": "8486948b-ee5f-47de-b80b-4aab14747f71",
       "username": "jack",
       "email": "jack@example.com",
       "emailVerified": true,
@@ -44,6 +45,7 @@
       ]
     },
     {
+      "id": "164a5904-51e6-48cf-af66-4aaba167ee84",
       "username": "carl",
       "email": "carl@example.com",
       "emailVerified": true,


### PR DESCRIPTION
## 概要

Keycloak の realm export (`config/keycloak/realm-export.json`) にデモユーザー jack / carl の `id` フィールドが含まれていなかったため、realm を新規インポートするたびに Keycloak がユーザー UUID を再生成し、JWT の `sub`(= Kong openid-connect が注入する `X-User-Id`)が環境ごとに変わっていた。

現在稼働中の環境の UUID を明示的に `id` として追記し、今後の再インポート(volume 削除後の起動など)でも `sub` が固定されるようにする。

## 変更点

- jack: `8486948b-ee5f-47de-b80b-4aab14747f71`
- carl: `164a5904-51e6-48cf-af66-4aaba167ee84`

`--import-realm` は既存 realm があるとスキップされるため、稼働中の環境への影響はない(現環境は既にこの UUID)。

## テスト結果

- `npm run format:check` — 変更ファイル `realm-export.json` は指摘なし(警告が出た 30 ファイルは既存・未追跡ファイルで本変更とは無関係)
- `node -e "JSON.parse(...)"` — JSON 構文 OK
- code-reviewer サブエージェントによるレビュー — 指摘なし(UUID v4 形式・一意性・Keycloak import セマンティクスを確認済み)
- TypeScript / テスト / compose.yaml — 変更対象外のため未実施

## Konnect 反映の要否

不要(`config/kong/kong.yaml` / `kongctl/` の変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)