### PR TITLE
feat: フロントエンドを Kong AI Portal 風フラット・ダークテーマへ刷新

### DIFF
--- a/services/frontend/src/app/globals.css
+++ b/services/frontend/src/app/globals.css
@@ -1,37 +1,98 @@
 /* ============================================================
-   Liquid Glass Design System
-   Background: neutral / clean
-   Interactive elements: Kong color scheme
-     accent #deff9a / #ccff00, secondary #92b600
+   Kong AI Portal 風 Flat Design System
+   参照: DESIGN.md（buildai.konghq.com / KUI トークン）
+   - 既定はダーク（黒背景 × ネオングリーン #CCFF00）。
+   - :root[data-theme='light'] で値だけ上書きしてライトテーマに切替。
+   - 半透明ガラス（backdrop-filter）・グロー系シャドウは使わないフラット設計。
    ============================================================ */
 
 :root {
-  /* Neutral base */
-  --bg: #f0f0f0;
+  color-scheme: dark;
+
+  /* Base（濃色） */
+  --bg: #000000;
+  --bg-alt: #000f06; /* ヒーロー等の濃色セクション（わずかに緑味） */
+  --bg-surface: #0d0e14; /* カード/サーフェス（不透明・フラット） */
+  --bg-surface-hover: #14161f;
+  --text: #ffffff;
+  --text-muted: #b7bdb5;
+  --text-on-accent: #000f06; /* アクセント背景上の文字色 */
+  --border: rgba(255, 255, 255, 0.12);
+  --border-strong: rgba(255, 255, 255, 0.24);
+
+  /* アクセント（Kong グリーンスケール） */
+  --accent-weakest: #faffe6;
+  --accent-weak: #dbff4d;
+  --accent: #ccff00; /* プライマリボタン・フォーカスリング・塗り */
+  --accent-strong: #b8e600; /* hover/active */
+  --accent-stronger: #dbff4d; /* 濃色背景上のアクセント文字（テーマで切替） */
+
+  /* ステータス色（バッジ・アラート） */
+  --status-success-text: #00d6a4;
+  --status-success-bg: rgba(0, 214, 164, 0.13);
+  --status-success-border: rgba(0, 214, 164, 0.4);
+  --status-warning-text: #ffc400;
+  --status-warning-bg: rgba(255, 196, 0, 0.13);
+  --status-warning-border: rgba(255, 196, 0, 0.4);
+  --status-danger-text: #ff3954;
+  --status-danger-bg: rgba(255, 57, 84, 0.13);
+  --status-danger-border: rgba(255, 57, 84, 0.4);
+  --status-info-text: #5f9aff;
+  --status-info-bg: rgba(95, 154, 255, 0.13);
+  --status-info-border: rgba(95, 154, 255, 0.4);
+
+  /* 角丸（6〜10px に統一） */
+  --radius-sm: 6px;
+  --radius: 8px;
+  --radius-lg: 10px;
+
+  /* フォーカスリング（KUI --kui-shadow-focus 相当） */
+  --focus-ring: 0 0 0 4px rgba(204, 255, 0, 0.2);
+
+  /* フォント（next/font が --font-inter / --font-jetbrains-mono を注入） */
+  --font-family: var(--font-inter), 'Inter', Roboto, Helvetica, sans-serif;
+  --font-family-code: var(--font-jetbrains-mono), 'JetBrains Mono', Consolas, monospace;
+
+  /* 後方互換エイリアス（TSX インラインスタイル / 旧トークン名の参照用）。
+     塗りは --accent、テキストは --accent-stronger に集約する。 */
+  --secondary: var(--accent-stronger);
+  --secondary-dark: var(--accent-stronger);
+  --accent-hover: var(--accent-strong);
+  --glass-border: var(--border);
+  --nav-bg: var(--bg);
+  --nav-text: var(--text);
+  --nav-text-muted: var(--text-muted);
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+
+  --bg: #ffffff;
+  --bg-alt: #f4f5f2;
+  --bg-surface: #ffffff;
+  --bg-surface-hover: #f7f8f5;
   --text: #1a1a1a;
-  --text-muted: #6b6b6b;
+  --text-muted: #5a5f57;
+  --text-on-accent: #000f06;
+  --border: rgba(0, 0, 0, 0.12);
+  --border-strong: rgba(0, 0, 0, 0.22);
 
-  /* Kong accent (buttons, interactive) */
-  --accent: #deff9a;
-  --accent-hover: #ccff00;
-  --secondary: #92b600;
-  --secondary-dark: #7a9900;
+  /* 明色背景ではアクセント文字を濃い緑にして可読性を確保（白地で約 4.9:1、WCAG AA 準拠） */
+  --accent-stronger: #5f7a00;
 
-  /* Liquid Glass */
-  --glass-bg: rgba(255, 255, 255, 0.45);
-  --glass-bg-hover: rgba(255, 255, 255, 0.62);
-  --glass-border: rgba(255, 255, 255, 0.6);
-  --glass-border-subtle: rgba(255, 255, 255, 0.35);
-  --glass-blur: 20px;
-  --glass-blur-strong: 32px;
-  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04);
-  --glass-shadow-hover: 0 16px 48px rgba(0, 0, 0, 0.1), 0 2px 6px rgba(0, 0, 0, 0.06);
-  --glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-
-  /* Nav */
-  --nav-bg: rgba(255, 255, 255, 0.55);
-  --nav-text: #1a1a1a;
-  --nav-text-muted: #666;
+  /* ステータス色は KUI のライト向け weakest 背景 + 濃色テキストを採用 */
+  --status-success-text: #00a17b;
+  --status-success-bg: #ecfffb;
+  --status-success-border: #00a17b;
+  --status-warning-text: #995c00;
+  --status-warning-bg: #fffce0;
+  --status-warning-border: #995c00;
+  --status-danger-text: #d60027;
+  --status-danger-bg: #ffe5e5;
+  --status-danger-border: #d60027;
+  --status-info-text: #0044f4;
+  --status-info-bg: #eefaff;
+  --status-info-border: #0044f4;
 }
 
 * {
@@ -41,9 +102,7 @@
 }
 
 body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, 'Helvetica Neue',
-    sans-serif;
+  font-family: var(--font-family);
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
@@ -51,12 +110,16 @@ body {
 }
 
 a {
-  color: var(--secondary-dark);
+  color: var(--accent-stronger);
   text-decoration: none;
 }
 a:hover {
-  color: var(--secondary);
+  color: var(--accent);
   text-decoration: none;
+}
+/* ライトは白背景。hover でネオンライムにすると溶けて消えるため、より濃い緑へ暗転させる。 */
+:root[data-theme='light'] a:hover {
+  color: #455900;
 }
 
 .container {
@@ -66,15 +129,12 @@ a:hover {
 }
 
 /* ============================================================
-   Navigation — Liquid Glass bar
+   Navigation — flat bar
    ============================================================ */
 .nav {
-  background: var(--nav-bg);
-  backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  -webkit-backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
-  box-shadow: 0 1px 12px rgba(0, 0, 0, 0.04);
-  color: var(--nav-text);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
   padding: 0.85rem 0;
   position: sticky;
   top: 0;
@@ -90,12 +150,12 @@ a:hover {
 }
 .nav-logo {
   font-size: 1.3rem;
-  font-weight: 700;
+  font-weight: 800;
   color: var(--text);
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 .nav-logo span {
-  color: var(--secondary);
+  color: var(--accent-stronger);
 }
 .nav-links {
   display: flex;
@@ -103,7 +163,7 @@ a:hover {
   align-items: center;
 }
 .nav-links a {
-  color: var(--nav-text-muted);
+  color: var(--text-muted);
   font-weight: 500;
   font-size: 0.92rem;
   transition: color 0.2s;
@@ -113,8 +173,8 @@ a:hover {
   text-decoration: none;
 }
 .nav-links a.nav-active {
-  color: var(--secondary-dark);
-  border-bottom: 2px solid var(--secondary);
+  color: var(--accent-stronger);
+  border-bottom: 2px solid var(--accent);
   padding-bottom: 4px;
   margin-bottom: -6px;
 }
@@ -126,8 +186,8 @@ a:hover {
   position: absolute;
   top: -8px;
   right: -12px;
-  background: var(--secondary);
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-on-accent);
   font-size: 0.68rem;
   font-weight: 700;
   min-width: 18px;
@@ -136,11 +196,42 @@ a:hover {
   text-align: center;
   border-radius: 9px;
   padding: 0 5px;
-  box-shadow: 0 2px 6px rgba(146, 182, 0, 0.35);
+}
+
+/* テーマ切替トグル / Ask AI トリガー（ヘッダー内のアイコンボタン） */
+.nav-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  height: 34px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
+}
+.nav-icon-btn:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.nav-icon-btn.nav-ask-ai {
+  color: var(--accent-stronger);
+  border-color: var(--accent);
+}
+.nav-icon-btn.nav-ask-ai:hover {
+  background: rgba(204, 255, 0, 0.1);
 }
 
 /* ============================================================
-   Product Grid + Liquid Glass Cards
+   Product Grid + Cards（flat）
    ============================================================ */
 .product-grid {
   display: grid;
@@ -150,41 +241,27 @@ a:hover {
 }
 
 .card {
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  border: 1px solid var(--glass-border);
-  border-radius: 20px;
-  overflow: hidden;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  box-shadow: var(--glass-shadow);
-}
-.card::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.8), transparent);
-}
-.card {
   position: relative;
   display: flex;
   flex-direction: column;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease;
 }
 .card:hover {
-  transform: translateY(-6px) scale(1.01);
-  background: var(--glass-bg-hover);
-  box-shadow: var(--glass-shadow-hover);
-  border-color: rgba(255, 255, 255, 0.8);
+  transform: translateY(-4px);
+  border-color: var(--border-strong);
 }
 
 .card-image {
   width: 100%;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  background: linear-gradient(135deg, rgba(240, 240, 240, 0.5), rgba(220, 220, 220, 0.3));
+  background: var(--bg-alt);
 }
 .card-image img {
   width: 100%;
@@ -209,86 +286,80 @@ a:hover {
 
 .card-title {
   font-size: 1.05rem;
-  font-weight: 600;
+  font-weight: 700;
   margin-bottom: 0.4rem;
   color: var(--text);
   line-height: 1.4;
 }
 .card-price {
   font-size: 1.3rem;
-  font-weight: 700;
-  color: var(--secondary-dark);
+  font-weight: 800;
+  color: var(--accent-stronger);
 }
 .card-category {
   display: inline-block;
-  background: rgba(146, 182, 0, 0.1);
-  color: var(--secondary-dark);
+  background: rgba(204, 255, 0, 0.1);
+  color: var(--accent-stronger);
   padding: 0.2rem 0.7rem;
-  border-radius: 20px;
+  border-radius: var(--radius-sm);
   font-size: 0.78rem;
   font-weight: 600;
   margin-bottom: 0.6rem;
-  border: 1px solid rgba(146, 182, 0, 0.2);
+  border: 1px solid rgba(204, 255, 0, 0.25);
 }
 
 /* ============================================================
-   Buttons — Kong accent colors
+   Buttons — flat
    ============================================================ */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.6rem 1.3rem;
+  padding: 0.55rem 1.1rem;
   border: none;
-  border-radius: 14px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.92rem;
   font-weight: 600;
-  transition: all 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 .btn-primary {
-  background: var(--secondary);
-  color: #fff;
-  box-shadow: 0 2px 12px rgba(146, 182, 0, 0.25);
+  background: var(--accent);
+  color: var(--text-on-accent);
 }
 .btn-primary:hover {
-  background: var(--secondary-dark);
-  box-shadow: 0 6px 24px rgba(146, 182, 0, 0.35);
-  transform: translateY(-1px);
+  background: var(--accent-strong);
 }
 .btn-primary:disabled {
   opacity: 0.45;
   cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
 }
 .btn-danger {
-  background: rgba(220, 53, 69, 0.9);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  color: white;
+  background: var(--status-danger-text);
+  color: #ffffff;
 }
 .btn-danger:hover {
-  background: #dc3545;
+  filter: brightness(1.1);
 }
 .btn-sm {
   padding: 0.3rem 0.75rem;
   font-size: 0.82rem;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
 }
 .btn-ghost {
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  color: var(--text);
-  border: 1px solid var(--glass-border-subtle);
+  background: transparent;
+  color: var(--accent-stronger);
+  border: 2px solid var(--accent);
 }
 .btn-ghost:hover {
-  background: var(--glass-bg-hover);
+  background: rgba(204, 255, 0, 0.1);
 }
 
 /* ============================================================
-   Forms — Liquid Glass inputs
+   Forms — flat inputs
    ============================================================ */
 .form-group {
   margin-bottom: 1.25rem;
@@ -303,103 +374,98 @@ a:hover {
 .form-group input {
   width: 100%;
   padding: 0.7rem 1rem;
-  background: rgba(255, 255, 255, 0.6);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border-subtle);
-  border-radius: 14px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   font-size: 1rem;
   color: var(--text);
-  transition: all 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
 }
 .form-group input:focus {
   outline: none;
-  border-color: var(--secondary);
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 0 0 3px rgba(146, 182, 0, 0.12);
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
 }
 .form-group input::placeholder {
   color: var(--text-muted);
 }
 
 /* ============================================================
-   Cart — Liquid Glass items
+   Cart — flat items
    ============================================================ */
 .cart-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.25rem;
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   margin-bottom: 0.6rem;
-  box-shadow: var(--glass-shadow);
-  transition: all 0.2s;
+  transition:
+    transform 0.2s,
+    border-color 0.2s;
 }
 .cart-item:hover {
-  background: var(--glass-bg-hover);
-  box-shadow: var(--glass-shadow-hover);
+  transform: translateY(-2px);
+  border-color: var(--border-strong);
 }
 .cart-total {
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 800;
   text-align: right;
   padding: 1.25rem 0;
   color: var(--text);
 }
 
 /* ============================================================
-   Orders — Liquid Glass cards
+   Orders — flat cards
    ============================================================ */
 .order-card {
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  border: 1px solid var(--glass-border);
-  border-radius: 20px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 1.5rem;
   margin-bottom: 1rem;
-  box-shadow: var(--glass-shadow);
-  transition: all 0.2s;
+  transition:
+    transform 0.2s,
+    border-color 0.2s;
 }
 .order-card:hover {
-  background: var(--glass-bg-hover);
-  box-shadow: var(--glass-shadow-hover);
+  transform: translateY(-2px);
+  border-color: var(--border-strong);
 }
 
 .status-badge {
   display: inline-block;
   padding: 0.2rem 0.75rem;
-  border-radius: 20px;
+  border-radius: var(--radius-sm);
   font-size: 0.78rem;
   font-weight: 600;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
 }
 .status-PENDING,
 .status-PROCESSING {
-  background: rgba(255, 193, 7, 0.15);
-  color: #8a6d00;
-  border: 1px solid rgba(255, 193, 7, 0.25);
+  background: var(--status-warning-bg);
+  color: var(--status-warning-text);
+  border: 1px solid var(--status-warning-border);
 }
 .status-CONFIRMED {
-  background: rgba(146, 182, 0, 0.12);
-  color: var(--secondary-dark);
-  border: 1px solid rgba(146, 182, 0, 0.25);
+  background: rgba(204, 255, 0, 0.12);
+  color: var(--accent-stronger);
+  border: 1px solid rgba(204, 255, 0, 0.3);
 }
 .status-SHIPPED,
 .status-IN_TRANSIT {
-  background: rgba(59, 130, 246, 0.1);
-  color: #1d4ed8;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: var(--status-info-bg);
+  color: var(--status-info-text);
+  border: 1px solid var(--status-info-border);
 }
 .status-DELIVERED {
-  background: rgba(34, 197, 94, 0.1);
-  color: #15803d;
-  border: 1px solid rgba(34, 197, 94, 0.2);
+  background: var(--status-success-bg);
+  color: var(--status-success-text);
+  border: 1px solid var(--status-success-border);
 }
 
 /* ============================================================
@@ -410,32 +476,30 @@ a:hover {
 }
 .page-header h1 {
   font-size: 1.75rem;
-  font-weight: 700;
+  font-weight: 800;
   color: var(--text);
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
 }
 
 /* ============================================================
-   Alerts — Liquid Glass
+   Alerts — flat
    ============================================================ */
 .alert {
   padding: 0.9rem 1.2rem;
-  border-radius: 14px;
+  border-radius: var(--radius);
   margin-bottom: 1rem;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
   font-weight: 500;
   font-size: 0.92rem;
 }
 .alert-error {
-  background: rgba(220, 53, 69, 0.08);
-  color: #b91c1c;
-  border: 1px solid rgba(220, 53, 69, 0.15);
+  background: var(--status-danger-bg);
+  color: var(--status-danger-text);
+  border: 1px solid var(--status-danger-border);
 }
 .alert-success {
-  background: rgba(146, 182, 0, 0.1);
-  color: var(--secondary-dark);
-  border: 1px solid rgba(146, 182, 0, 0.2);
+  background: var(--status-success-bg);
+  color: var(--status-success-text);
+  border: 1px solid var(--status-success-border);
 }
 
 /* ============================================================
@@ -446,7 +510,7 @@ a:hover {
 }
 
 /* ============================================================
-   Filter pills — Liquid Glass
+   Filter pills — flat
    ============================================================ */
 .filter-bar {
   display: flex;
@@ -456,31 +520,31 @@ a:hover {
 }
 .filter-btn {
   padding: 0.4rem 1rem;
-  border: 1px solid var(--glass-border-subtle);
-  border-radius: 20px;
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
   cursor: pointer;
   font-size: 0.85rem;
   font-weight: 500;
   color: var(--text-muted);
-  transition: all 0.2s;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s;
 }
 .filter-btn:hover {
-  background: var(--glass-bg-hover);
+  background: var(--bg-surface-hover);
   color: var(--text);
-  border-color: rgba(146, 182, 0, 0.35);
+  border-color: var(--border-strong);
 }
 .filter-btn.active {
-  background: var(--secondary);
-  color: #fff;
-  border-color: var(--secondary);
-  box-shadow: 0 2px 10px rgba(146, 182, 0, 0.25);
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border-color: var(--accent);
 }
 
 /* ============================================================
-   Quantity controls — Liquid Glass
+   Quantity controls — flat
    ============================================================ */
 .qty-controls {
   display: flex;
@@ -490,11 +554,9 @@ a:hover {
 .qty-btn {
   width: 34px;
   height: 34px;
-  border: 1px solid var(--glass-border-subtle);
-  border-radius: 10px;
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
   cursor: pointer;
   font-size: 1.1rem;
   font-weight: 600;
@@ -502,33 +564,33 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 .qty-btn:hover {
-  background: var(--glass-bg-hover);
-  border-color: var(--secondary);
-  color: var(--secondary-dark);
+  background: var(--bg-surface-hover);
+  border-color: var(--accent);
+  color: var(--accent-stronger);
 }
 
 /* ============================================================
-   Auth form — Liquid Glass card
+   Auth form — flat card
    ============================================================ */
 .auth-form {
   max-width: 420px;
   margin: 3rem auto;
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  -webkit-backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  border: 1px solid var(--glass-border);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   padding: 2.5rem 2rem;
-  border-radius: 24px;
-  box-shadow: var(--glass-shadow-hover);
+  border-radius: var(--radius-lg);
 }
 .auth-form h1 {
   margin-bottom: 2rem;
   text-align: center;
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-weight: 800;
+  letter-spacing: -0.02em;
 }
 
 /* ============================================================
@@ -536,7 +598,7 @@ a:hover {
    ============================================================ */
 ::selection {
   background: var(--accent);
-  color: var(--text);
+  color: var(--text-on-accent);
 }
 
 /* ============================================================
@@ -557,18 +619,19 @@ a:hover {
   bottom: 2rem;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  border: 1px solid var(--glass-border);
-  color: var(--secondary-dark);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--accent-stronger);
   padding: 0.75rem 1.5rem;
-  border-radius: 16px;
+  border-radius: var(--radius);
   font-weight: 600;
   font-size: 0.92rem;
-  box-shadow: var(--glass-shadow-hover);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   z-index: 200;
   animation: toast-fade-in 0.3s ease;
+}
+:root[data-theme='light'] .toast {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 /* ============================================================
@@ -585,7 +648,7 @@ a:hover {
 }
 .error-boundary h2 {
   font-size: 1.5rem;
-  font-weight: 700;
+  font-weight: 800;
   color: var(--text);
   margin-bottom: 0.75rem;
 }
@@ -596,73 +659,37 @@ a:hover {
 }
 
 /* ============================================================
-   Ask AI — Floating button + chat dialog
+   Ask AI — chat dialog（トリガーは Nav ヘッダー内。FAB は廃止）
    ============================================================ */
-.ask-ai-fab {
-  position: fixed !important;
-  bottom: 24px !important;
-  right: 24px !important;
-  left: auto !important;
-  top: auto !important;
-  min-width: 60px;
-  min-height: 60px;
-  width: 60px;
-  height: 60px;
-  border: 1px solid var(--glass-border);
-  border-radius: 50%;
-  background: var(--glass-bg);
-  backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  -webkit-backdrop-filter: blur(var(--glass-blur-strong)) saturate(180%);
-  color: var(--secondary-dark);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow: var(--glass-shadow), var(--glass-inset);
-  z-index: 9999;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  margin: 0;
-}
-.ask-ai-fab:hover {
-  background: var(--glass-bg-hover);
-  border-color: rgba(146, 182, 0, 0.4);
-  transform: scale(1.1);
-  box-shadow: var(--glass-shadow-hover), var(--glass-inset);
-}
-
 .ask-ai-dialog {
   position: fixed !important;
-  bottom: 100px !important;
+  top: 76px !important;
   right: 24px !important;
+  bottom: auto !important;
   left: auto !important;
-  top: auto !important;
   width: 420px;
   max-width: calc(100vw - 48px);
   height: 560px;
-  max-height: calc(100vh - 140px);
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(28px) saturate(180%);
-  -webkit-backdrop-filter: blur(28px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.7);
-  border-radius: 24px;
-  box-shadow:
-    0 20px 60px rgba(0, 0, 0, 0.12),
-    0 4px 16px rgba(0, 0, 0, 0.06);
+  max-height: calc(100vh - 100px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   z-index: 9999;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  animation: ask-ai-slide-up 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: ask-ai-slide-down 0.25s cubic-bezier(0.16, 1, 0.3, 1);
   margin: 0;
   padding: 0;
 }
-@keyframes ask-ai-slide-up {
+:root[data-theme='light'] .ask-ai-dialog {
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.16);
+}
+@keyframes ask-ai-slide-down {
   from {
     opacity: 0;
-    transform: translateY(16px) scale(0.96);
+    transform: translateY(-12px) scale(0.98);
   }
   to {
     opacity: 1;
@@ -671,16 +698,41 @@ a:hover {
 }
 
 .ask-ai-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
-  background: rgba(255, 255, 255, 0.4);
+  background: var(--bg-alt);
 }
 .ask-ai-title {
   font-weight: 700;
   font-size: 1.05rem;
   color: var(--text);
   letter-spacing: -0.01em;
+}
+.ask-ai-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+.ask-ai-close:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text);
 }
 
 .ask-ai-messages {
@@ -710,25 +762,29 @@ a:hover {
   align-items: flex-start;
   gap: 0.4rem;
   padding: 0.7rem 0.9rem 0.85rem;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  border-top: 1px solid var(--border);
 }
 .ask-ai-suggestion-chip {
   max-width: 100%;
   padding: 0.45rem 0.9rem;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-alt);
   cursor: pointer;
   font-size: 0.82rem;
   color: var(--text);
   text-align: left;
-  transition: all 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    transform 0.15s;
   line-height: 1.3;
 }
 .ask-ai-suggestion-chip:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.85);
-  border-color: var(--secondary);
-  color: var(--secondary-dark);
+  background: var(--bg-surface-hover);
+  border-color: var(--accent);
+  color: var(--accent-stronger);
   transform: translateX(2px);
 }
 .ask-ai-suggestion-chip:disabled {
@@ -745,7 +801,7 @@ a:hover {
 .ask-ai-msg-content {
   max-width: 82%;
   padding: 0.65rem 1rem;
-  border-radius: 18px;
+  border-radius: var(--radius-lg);
   font-size: 0.9rem;
   line-height: 1.55;
   word-break: break-word;
@@ -789,23 +845,22 @@ a:hover {
   font-weight: 700;
 }
 .ask-ai-msg-assistant .ask-ai-msg-content code {
-  background: rgba(0, 0, 0, 0.06);
+  background: rgba(128, 128, 128, 0.2);
   padding: 0.1rem 0.35rem;
   border-radius: 4px;
   font-size: 0.84rem;
+  font-family: var(--font-family-code);
 }
 .ask-ai-msg-user .ask-ai-msg-content {
-  background: var(--secondary);
-  color: #fff;
-  border-bottom-right-radius: 6px;
-  box-shadow: 0 2px 8px rgba(146, 182, 0, 0.2);
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border-bottom-right-radius: var(--radius-sm);
 }
 .ask-ai-msg-assistant .ask-ai-msg-content {
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
   color: var(--text);
-  border-bottom-left-radius: 6px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  border-bottom-left-radius: var(--radius-sm);
 }
 
 /* Typing indicator */
@@ -846,26 +901,27 @@ a:hover {
   display: flex;
   gap: 0.5rem;
   padding: 0.85rem 1rem;
-  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  border-top: 1px solid var(--border);
   flex-shrink: 0;
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--bg-alt);
 }
 .ask-ai-input-bar input {
   flex: 1;
   min-width: 0;
   padding: 0.65rem 1rem;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
   font-size: 0.9rem;
   color: var(--text);
   outline: none;
-  transition: all 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
 }
 .ask-ai-input-bar input:focus {
-  border-color: var(--secondary);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 0 0 3px rgba(146, 182, 0, 0.12);
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
 }
 .ask-ai-input-bar input::placeholder {
   color: var(--text-muted);
@@ -873,39 +929,20 @@ a:hover {
 .ask-ai-send {
   padding: 0.65rem 1.1rem;
   border: none;
-  border-radius: 14px;
-  background: var(--secondary);
-  color: #fff;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--text-on-accent);
   font-weight: 600;
   font-size: 0.88rem;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background 0.15s;
   flex-shrink: 0;
   white-space: nowrap;
-  box-shadow: 0 2px 8px rgba(146, 182, 0, 0.2);
 }
 .ask-ai-send:hover {
-  background: var(--secondary-dark);
-  box-shadow: 0 4px 12px rgba(146, 182, 0, 0.3);
+  background: var(--accent-strong);
 }
 .ask-ai-send:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-  box-shadow: none;
-}
-
-/* Soft gradient blobs for depth behind glass */
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background:
-    radial-gradient(ellipse 600px 600px at 15% 20%, rgba(146, 182, 0, 0.07) 0%, transparent 100%),
-    radial-gradient(ellipse 500px 500px at 85% 75%, rgba(204, 255, 0, 0.05) 0%, transparent 100%),
-    radial-gradient(ellipse 400px 400px at 50% 10%, rgba(222, 255, 154, 0.06) 0%, transparent 100%);
-  z-index: -1;
-  pointer-events: none;
 }

--- a/services/frontend/src/app/layout.tsx
+++ b/services/frontend/src/app/layout.tsx
@@ -1,18 +1,39 @@
 import type { Metadata } from 'next'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import AskAIDialog from '@/components/AskAIDialog'
 import Providers from '@/components/Providers'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: 'Jungle Shop',
   description: 'Kong Konnect デモ EC サイト',
 }
 
+// 初回ペイント前にテーマを適用する no-flash スクリプト。既定はダークで、ユーザーが
+// 手動でライトに切替えた場合のみ localStorage('theme') に 'light' が入る（lib/theme.ts）。
+const themeInitScript = `(function(){try{if(localStorage.getItem('theme')==='light'){document.documentElement.setAttribute('data-theme','light');}}catch(e){}})();`
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
+    <html
+      lang="ja"
+      suppressHydrationWarning
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+    >
       <body>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <Providers>
           <ErrorBoundary>{children}</ErrorBoundary>
           <AskAIDialog />

--- a/services/frontend/src/components/AskAIDialog.tsx
+++ b/services/frontend/src/components/AskAIDialog.tsx
@@ -25,23 +25,33 @@ export default function AskAIDialog() {
   const [suggestions, setSuggestions] = useState<string[]>([])
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
-  const fabRef = useRef<HTMLButtonElement>(null)
+
+  // トリガーは Nav ヘッダー（[data-ask-ai-trigger]）にあり、'ask-ai-toggle' イベントで開閉する。
+  useEffect(() => {
+    const handleToggle = () => setOpen((o) => !o)
+    window.addEventListener('ask-ai-toggle', handleToggle)
+    return () => window.removeEventListener('ask-ai-toggle', handleToggle)
+  }, [])
 
   useEffect(() => {
     if (!open) return
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as Node
-      if (
-        dialogRef.current &&
-        !dialogRef.current.contains(target) &&
-        fabRef.current &&
-        !fabRef.current.contains(target)
-      ) {
+      // ヘッダーのトリガー押下はトグル側に委ねる（ここで閉じると二重処理になる）。
+      if (target instanceof Element && target.closest('[data-ask-ai-trigger]')) return
+      if (dialogRef.current && !dialogRef.current.contains(target)) {
         setOpen(false)
       }
     }
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
     document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
   }, [open])
 
   useEffect(() => {
@@ -100,25 +110,25 @@ export default function AskAIDialog() {
     }
   }
 
-  // AI チャットはログイン必須。未認証（RefreshTokenError 含む）では FAB を出さない。
-  // バックエンド側も Kong の openid-connect で agent 系ルートを保護している（多層防御）。
+  // AI チャットはログイン必須。未認証（RefreshTokenError 含む）ではダイアログを出さない。
+  // トリガー（Nav の Ask AI ボタン）も認証時のみ表示され、バックエンドも Kong の
+  // openid-connect で agent 系ルートを保護している（多層防御）。
   if (status !== 'authenticated') return null
 
   return (
     <>
-      <button
-        ref={fabRef}
-        className="ask-ai-fab"
-        onClick={() => setOpen(!open)}
-        aria-label="AI に質問"
-      >
-        {open ? '✕' : '✨'}
-      </button>
-
       {open && (
         <div ref={dialogRef} className="ask-ai-dialog">
           <div className="ask-ai-header">
             <span className="ask-ai-title">Ask Gorilla</span>
+            <button
+              type="button"
+              className="ask-ai-close"
+              onClick={() => setOpen(false)}
+              aria-label="閉じる"
+            >
+              ✕
+            </button>
           </div>
 
           <div className="ask-ai-messages">

--- a/services/frontend/src/components/Nav.tsx
+++ b/services/frontend/src/components/Nav.tsx
@@ -7,6 +7,7 @@ import { signOut } from 'next-auth/react'
 import { useAuthUser } from '@/lib/auth'
 import { apiFetch } from '@/lib/api'
 import GrafanaIcon from '@/components/GrafanaIcon'
+import ThemeToggle from '@/components/ThemeToggle'
 
 export default function Nav() {
   const pathname = usePathname()
@@ -63,6 +64,18 @@ export default function Nav() {
             <GrafanaIcon />
             Grafana
           </a>
+          {user && (
+            <button
+              type="button"
+              className="nav-icon-btn nav-ask-ai"
+              data-ask-ai-trigger
+              onClick={() => window.dispatchEvent(new Event('ask-ai-toggle'))}
+              aria-label="AI に質問"
+            >
+              ✨ Ask AI
+            </button>
+          )}
+          <ThemeToggle />
           {user ? (
             <>
               <span

--- a/services/frontend/src/components/ThemeToggle.tsx
+++ b/services/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getResolvedTheme, toggleTheme, type Theme } from '@/lib/theme'
+
+/**
+ * ライト/ダークの手動切替ボタン。既定はダーク（DESIGN.md の Kong AI Portal 風）。
+ * 初期テーマは layout.tsx の no-flash スクリプトが `<html data-theme>` に反映済みで、
+ * ここはマウント後に DOM の実効テーマへ表示を同期し、クリックでトグルする。
+ */
+export default function ThemeToggle() {
+  // SSR とクライアント初期描画を一致させるため、マウント前はダーク前提で描画する。
+  const [theme, setThemeState] = useState<Theme>('dark')
+
+  useEffect(() => {
+    setThemeState(getResolvedTheme())
+  }, [])
+
+  const handleToggle = () => {
+    setThemeState(toggleTheme())
+  }
+
+  const isDark = theme === 'dark'
+  return (
+    <button
+      type="button"
+      className="nav-icon-btn"
+      onClick={handleToggle}
+      aria-label={isDark ? 'ライトテーマに切替' : 'ダークテーマに切替'}
+      title={isDark ? 'ライトテーマに切替' : 'ダークテーマに切替'}
+    >
+      {isDark ? '☀️' : '🌙'}
+    </button>
+  )
+}

--- a/services/frontend/src/components/__tests__/AskAIDialog.test.tsx
+++ b/services/frontend/src/components/__tests__/AskAIDialog.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { createRoot } from 'react-dom/client'
 
 // useSession をモックすれば useAuthUser 経由のゲートを検証できる。
 vi.mock('next-auth/react', () => ({
@@ -9,33 +11,42 @@ vi.mock('next-auth/react', () => ({
 vi.mock('react-markdown', () => ({
   default: ({ children }: { children: string }) => children,
 }))
+// 開くとサジェスト取得が走るためネットワークをモックする。
+vi.mock('@/lib/api', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ suggestions: [] }),
+}))
 
 import { useSession } from 'next-auth/react'
 import AskAIDialog from '../AskAIDialog'
 
 const mockedUseSession = vi.mocked(useSession)
 
+// React 19 の act 環境フラグ。
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const authenticatedSession = {
+  data: {
+    user: { id: 'kc-sub-123', email: 'jack@example.com', name: 'Jack Driscoll' },
+    expires: '2999-01-01',
+  },
+  status: 'authenticated',
+} as never
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('AskAIDialog 認証ゲート', () => {
-  it('未認証のときは何も描画しない（FAB を表示しない）', () => {
+  it('未認証のときは何も描画しない', () => {
     mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' } as never)
     const html = renderToStaticMarkup(<AskAIDialog />)
     expect(html).toBe('')
   })
 
-  it('認証済みのときは FAB を描画する', () => {
-    mockedUseSession.mockReturnValue({
-      data: {
-        user: { id: 'kc-sub-123', email: 'jack@example.com', name: 'Jack Driscoll' },
-        expires: '2999-01-01',
-      },
-      status: 'authenticated',
-    } as never)
+  it('認証済みでも初期状態（未オープン）ではダイアログを描画しない', () => {
+    mockedUseSession.mockReturnValue(authenticatedSession)
     const html = renderToStaticMarkup(<AskAIDialog />)
-    expect(html).toContain('ask-ai-fab')
+    expect(html).toBe('')
   })
 
   it('RefreshTokenError のセッションは未認証扱いで描画しない', () => {
@@ -49,5 +60,37 @@ describe('AskAIDialog 認証ゲート', () => {
     } as never)
     const html = renderToStaticMarkup(<AskAIDialog />)
     expect(html).toBe('')
+  })
+})
+
+describe('AskAIDialog ヘッダートリガー連携', () => {
+  it("'ask-ai-toggle' イベントでダイアログを開閉する", async () => {
+    mockedUseSession.mockReturnValue(authenticatedSession)
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<AskAIDialog />)
+    })
+    // 初期は閉じている
+    expect(container.querySelector('.ask-ai-dialog')).toBeNull()
+
+    // トリガー → 開く
+    await act(async () => {
+      window.dispatchEvent(new Event('ask-ai-toggle'))
+    })
+    expect(container.querySelector('.ask-ai-dialog')).not.toBeNull()
+
+    // 再度トリガー → 閉じる
+    await act(async () => {
+      window.dispatchEvent(new Event('ask-ai-toggle'))
+    })
+    expect(container.querySelector('.ask-ai-dialog')).toBeNull()
+
+    await act(async () => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
   })
 })

--- a/services/frontend/src/lib/__tests__/theme.test.ts
+++ b/services/frontend/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  THEME_STORAGE_KEY,
+  getStoredTheme,
+  getInitialTheme,
+  getResolvedTheme,
+  applyTheme,
+  setTheme,
+  toggleTheme,
+} from '../theme'
+
+beforeEach(() => {
+  window.localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('theme: getStoredTheme / getInitialTheme', () => {
+  it('未設定なら getStoredTheme は null、getInitialTheme は dark（既定）', () => {
+    expect(getStoredTheme()).toBeNull()
+    expect(getInitialTheme()).toBe('dark')
+  })
+
+  it('保存された light/dark を読み出す', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    expect(getStoredTheme()).toBe('light')
+    expect(getInitialTheme()).toBe('light')
+  })
+
+  it('不正値は null 扱いで既定 dark にフォールバック', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'blue')
+    expect(getStoredTheme()).toBeNull()
+    expect(getInitialTheme()).toBe('dark')
+  })
+})
+
+describe('theme: applyTheme / getResolvedTheme', () => {
+  it('light は data-theme=light を付与、dark は属性を外す', () => {
+    applyTheme('light')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    expect(getResolvedTheme()).toBe('light')
+
+    applyTheme('dark')
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
+    expect(getResolvedTheme()).toBe('dark')
+  })
+})
+
+describe('theme: setTheme', () => {
+  it('DOM 反映と localStorage 永続化を両方行う', () => {
+    setTheme('light')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+  })
+})
+
+describe('theme: toggleTheme', () => {
+  it('既定(dark)から light へ、もう一度で dark へ戻る', () => {
+    expect(getResolvedTheme()).toBe('dark')
+
+    expect(toggleTheme()).toBe('light')
+    expect(getResolvedTheme()).toBe('light')
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+
+    expect(toggleTheme()).toBe('dark')
+    expect(getResolvedTheme()).toBe('dark')
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+  })
+})

--- a/services/frontend/src/lib/theme.ts
+++ b/services/frontend/src/lib/theme.ts
@@ -1,0 +1,67 @@
+'use client'
+
+/**
+ * ライト/ダークのテーマ切替ロジック。
+ *
+ * - 既定はダーク（DESIGN.md の Kong AI Portal 風）。
+ * - ユーザーが手動トグルした場合のみ localStorage に永続化する。
+ * - 実際の反映は `<html data-theme="light">` 属性の付け外しで行い、値の解決は
+ *   `globals.css` の `:root` / `:root[data-theme='light']` が担う。
+ *
+ * no-flash 初期化（初回ペイント前の属性適用）は `layout.tsx` のインラインスクリプトで行い、
+ * ここは主にトグル操作とテスト可能な純ロジックを提供する。
+ */
+
+export type Theme = 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'theme'
+
+/** localStorage に保存されたテーマを返す。未設定・不正値・SSR では null。 */
+export function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const v = window.localStorage.getItem(THEME_STORAGE_KEY)
+    return v === 'light' || v === 'dark' ? v : null
+  } catch {
+    return null
+  }
+}
+
+/** 保存値が無ければ既定（dark）を採用した現在の実効テーマ。 */
+export function getInitialTheme(): Theme {
+  return getStoredTheme() ?? 'dark'
+}
+
+/** `<html>` の data-theme 属性へ反映する（dark は既定なので属性を外す）。 */
+export function applyTheme(theme: Theme): void {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  if (theme === 'light') {
+    root.setAttribute('data-theme', 'light')
+  } else {
+    root.removeAttribute('data-theme')
+  }
+}
+
+/** テーマを保存して DOM に反映する。 */
+export function setTheme(theme: Theme): void {
+  applyTheme(theme)
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+  } catch {
+    /* localStorage 不可の環境では永続化のみスキップ（表示は反映済み） */
+  }
+}
+
+/** 現在のテーマを反転して保存・反映し、切替後のテーマを返す。 */
+export function toggleTheme(): Theme {
+  const next: Theme = getResolvedTheme() === 'light' ? 'dark' : 'light'
+  setTheme(next)
+  return next
+}
+
+/** DOM の現在状態（data-theme 属性の有無）から実効テーマを解決する。 */
+export function getResolvedTheme(): Theme {
+  if (typeof document === 'undefined') return getInitialTheme()
+  return document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark'
+}


### PR DESCRIPTION
## 概要

`DESIGN.md`（[buildai.konghq.com](https://buildai.konghq.com/) / Kong 公式デザインシステム KUI トークン準拠）に沿って、現行の **Liquid Glass**（ライト・半透明ガラス風）UI を **フラット × ダーク（ネオングリーン `#CCFF00`）** デザインへ刷新します。

対象は `services/frontend` のみ。サービス間コントラクト（Kafka / Kong ルート / `X-User-*` / API 形状）には一切触れていません。

## 変更点

- **テーマ機構（ダーク既定 + 手動トグル）**
  - `globals.css` の `:root` をダーク既定にし、`:root[data-theme='light']` でライト値を上書き。
  - 既存の CSS カスタムプロパティ名（`--secondary` 等）を**エイリアスとして残し**、TSX のインラインスタイルは無改修で追随。
  - `ThemeToggle`（Nav 配置、`localStorage` 永続化）+ `layout.tsx` の no-flash インラインスクリプト + `suppressHydrationWarning`。テーマ操作ロジックは `lib/theme.ts` に分離。
- **フラット化**: 全 `backdrop-filter` / グロー系シャドウを撤去、角丸 6〜10px に統一、ステータス色・フォーカスリングをトークン化、`body::before` のグローブロブを撤去。ボタン primary は `--accent` 背景 + 濃色文字。
- **Ask AI をヘッダーへ移動**: 右下 FAB を廃止し、Nav のトリガーボタン（`window` カスタムイベント `ask-ai-toggle`）へ。ダイアログに閉じる（✕）ボタン + Escape を追加。
- **フォント**: Inter（本文・見出し）+ JetBrains Mono（コード）を `next/font` で導入。

## スコープ外

コードウィンドウ UI・ヒーロー再構成・グリッド背景モチーフ（DESIGN.md の「新規コンポーネント」群）。データ/ロジック変更なし。

## 検証

- `npm run build` 成功 / `npx tsc --noEmit` エラーなし / `npx vitest run` **45 passed**（`lib/theme` と Ask AI イベント開閉のテスト追加）/ prettier 通過。
- Playwright でダーク・ライト両テーマとトグル動作・永続化を目視確認。
- `code-reviewer` レビュー実施 → ライトテーマのコントラスト指摘（リンク hover / `--accent-stronger` の AA）を修正済み。

## スクリーンショット

| ダーク（既定） | ライト（トグル切替） |
| --- | --- |
| 黒背景 + ライムのプライマリボタン、フラットカード | 白背景 + 濃緑アクセント（AA 準拠）、フラットカード |

> 目視確認済み（cart/orders/AskAI ダイアログは要 Keycloak ログインのため本 PR では未掲載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)